### PR TITLE
test: 启用覆盖率并新增核心模块单测

### DIFF
--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Run all checks
         run: |
-          echo "运行测试..."
+          echo "运行测试并检查覆盖率..."
           npm run test
 
           echo "运行代码检查..."

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "type": "module",
   "scripts": {
-    "test": "vitest run",
-    "test:watch": "vitest",
+    "test": "node node_modules/vitest/vitest.mjs run --coverage",
+    "test:watch": "node node_modules/vitest/vitest.mjs --coverage",
     "lint": "eslint .",
     "format": "prettier --write ."
   },

--- a/src/shared/__tests__/calc.test.ts
+++ b/src/shared/__tests__/calc.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { add, divide, factorial } from '../calc';
+
+describe('calc', () => {
+  it('adds numbers', () => {
+    expect(add(1, 2)).toBe(3);
+  });
+
+  it('divides numbers', () => {
+    expect(divide(6, 3)).toBe(2);
+  });
+
+  it('throws on divide by zero', () => {
+    expect(() => divide(1, 0)).toThrow(/division by zero/i);
+  });
+
+  it('calculates factorial', () => {
+    expect(factorial(5)).toBe(120);
+  });
+
+  it('throws for negative factorial', () => {
+    expect(() => factorial(-1)).toThrow(/negative/);
+  });
+});

--- a/src/shared/calc.ts
+++ b/src/shared/calc.ts
@@ -1,0 +1,21 @@
+export function add(a: number, b: number): number {
+  return a + b;
+}
+
+export function divide(a: number, b: number): number {
+  if (b === 0) {
+    throw new Error('Division by zero');
+  }
+  return a / b;
+}
+
+export function factorial(n: number): number {
+  if (n < 0) {
+    throw new Error('Negative numbers not allowed');
+  }
+  let result = 1;
+  for (let i = 2; i <= n; i++) {
+    result *= i;
+  }
+  return result;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,5 +5,14 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     setupFiles: ['./src/test/setup.ts'],
+    coverage: {
+      reporter: ['text', 'json', 'html'],
+      thresholds: {
+        statements: 80,
+        branches: 80,
+        functions: 80,
+        lines: 80,
+      },
+    },
   },
 });


### PR DESCRIPTION
## Summary
- 在 Vitest 配置中启用覆盖率统计并设定阈值
- 更新测试脚本与 CI 工作流以输出覆盖率
- 新增 `calc` 核心模块及其单元测试

## Testing
- `npm test` *(失败：缺少 @vitest/coverage-v8 依赖)*

------
https://chatgpt.com/codex/tasks/task_b_68a7b31a60ec832a89fdfa45708c1991