### PR TITLE
chore: 添加贡献指南并配置提交规范工具

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+npx --no-install commitlint --edit "$1"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,10 +4,11 @@
 
 ## 提交流程
 
-1. 从 `main` 分支创建功能分支，例如：`git checkout -b feature/your-feature`。
-2. 开发过程中请保持提交粒度清晰，完成一个独立功能或修复后再提交。
-3. 提交前运行 `npm run lint` 与 `npm test` 确保没有格式与测试问题。
-4. 推送分支并提交 Pull Request 以便代码审查。
+1. 克隆仓库后先运行 `npm install`，以安装依赖并配置 Husky 钩子。
+2. 从 `main` 分支创建功能分支，例如：`git checkout -b feature/your-feature`。
+3. 开发过程中请保持提交粒度清晰，完成一个独立功能或修复后再提交。
+4. 提交前运行 `npm run lint` 与 `npm test` 确保没有格式与测试问题。
+5. 推送分支并提交 Pull Request 以便代码审查。
 
 ## 分支策略
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,41 @@
+# 贡献指南
+
+感谢你愿意为本项目贡献代码！请遵循以下约定以保持代码质量与仓库整洁。
+
+## 提交流程
+
+1. 从 `main` 分支创建功能分支，例如：`git checkout -b feature/your-feature`。
+2. 开发过程中请保持提交粒度清晰，完成一个独立功能或修复后再提交。
+3. 提交前运行 `npm run lint` 与 `npm test` 确保没有格式与测试问题。
+4. 推送分支并提交 Pull Request 以便代码审查。
+
+## 分支策略
+
+- `main` 为稳定分支，所有功能与修复都通过合并请求进入此分支。
+- 功能分支建议以 `feature/`、`fix/` 等前缀命名。
+
+## 代码格式
+
+- 使用 [Prettier](https://prettier.io/) 与 [ESLint](https://eslint.org/) 保持统一风格。
+- 提交前请运行 `npm run format` 与 `npm run lint`。
+
+## Commit 信息规范
+
+本项目采用 [Conventional Commits](https://www.conventionalcommits.org/) 规范，提交信息将通过 commitlint 在 commit-msg 钩子中自动校验。
+
+常用类型：
+
+- `feat`: 新功能
+- `fix`: 修复问题
+- `docs`: 文档变更
+- `chore`: 构建流程或辅助工具变更
+
+示例：
+
+```bash
+feat: 增加用户登录功能
+```
+
+Commit 信息由类型、可选范围和简短描述组成，冒号后需紧跟一个空格。
+
+感谢你的贡献！

--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['@commitlint/config-conventional']
+};

--- a/package.json
+++ b/package.json
@@ -6,13 +6,17 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "lint": "eslint .",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "prepare": "husky install"
   },
   "devDependencies": {
+    "@commitlint/cli": "^19.0.0",
+    "@commitlint/config-conventional": "^19.0.0",
     "@eslint/js": "^9.33.0",
     "eslint": "^9.33.0",
     "grunt": "^1.6.1",
     "grunt-contrib-copy": "^1.0.0",
+    "husky": "^9.0.10",
     "jsdom": "^26.1.0",
     "prettier": "^3.2.5",
     "vitest": "^3.2.4"


### PR DESCRIPTION
## Summary
- 添加 `CONTRIBUTING.md`，说明提交流程、分支策略及代码格式，并给出 Conventional Commits 示例
- 引入 commitlint 与 husky，新增 commit-msg 钩子以校验提交信息
- 更新 `package.json`，加入相关依赖与 `prepare` 脚本

## Testing
- `npm test` *(失败：vitest: not found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68a7b31771e8832a96d1f6e4d0488b04