### PR TITLE
feat: 接入大模型生成蓝图并扩展步骤信息

### DIFF
--- a/src/flow/__tests__/renderFlow.test.ts
+++ b/src/flow/__tests__/renderFlow.test.ts
@@ -1,10 +1,31 @@
 import { describe, it, expect } from 'vitest';
 import { renderFlow } from '../renderFlow';
-import { generateBlueprint } from '../../ideas/generateBlueprint';
+import type { Blueprint } from '../../ideas/generateBlueprint';
+
+const blueprint: Blueprint = {
+  requirement: '',
+  steps: [
+    {
+      id: 'start',
+      label: '开始',
+      description: '',
+      inputs: [],
+      outputs: [],
+      next: ['end'],
+    },
+    {
+      id: 'end',
+      label: '结束',
+      description: '',
+      inputs: [],
+      outputs: [],
+      next: [],
+    },
+  ],
+};
 
 describe('renderFlow', () => {
   it('返回包含节点和边的 ReactFlow 对象', () => {
-    const blueprint = generateBlueprint('');
     const flow = renderFlow(blueprint);
     expect(flow.type).toBe('ReactFlow');
     expect(flow.nodes).toBeDefined();

--- a/src/ideas/__tests__/generateBlueprint.test.ts
+++ b/src/ideas/__tests__/generateBlueprint.test.ts
@@ -1,10 +1,46 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { generateBlueprint } from '../generateBlueprint';
 
+const mockSteps = [
+  {
+    id: 'start',
+    label: '开始',
+    description: '开始步骤',
+    inputs: [],
+    outputs: ['signal'],
+    next: ['end'],
+  },
+  {
+    id: 'end',
+    label: '结束',
+    description: '结束步骤',
+    inputs: ['signal'],
+    outputs: [],
+    next: [],
+  },
+];
+
 describe('generateBlueprint', () => {
-  it('返回包含步骤的蓝图', () => {
-    const blueprint = generateBlueprint('任意需求');
-    expect(blueprint.steps.length).toBeGreaterThan(0);
-    expect(blueprint.steps[0]).toHaveProperty('id');
+  beforeEach(() => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        json: async () => ({
+          choices: [{ message: { content: JSON.stringify(mockSteps) } }],
+        }),
+      })),
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('返回包含描述和输入输出的蓝图', async () => {
+    const blueprint = await generateBlueprint('任意需求');
+    expect(blueprint.steps).toHaveLength(2);
+    expect(blueprint.steps[0]).toHaveProperty('description');
+    expect(Array.isArray(blueprint.steps[0].inputs)).toBe(true);
+    expect(Array.isArray(blueprint.steps[0].outputs)).toBe(true);
   });
 });

--- a/src/ideas/generateBlueprint.ts
+++ b/src/ideas/generateBlueprint.ts
@@ -1,6 +1,9 @@
 export interface BlueprintStep {
   id: string;
   label: string;
+  description: string;
+  inputs: string[];
+  outputs: string[];
   next: string[];
 }
 
@@ -12,14 +15,38 @@ export interface Blueprint {
 /**
  * 根据文本需求生成蓝图。当前实现返回固定示例。
  */
-export function generateBlueprint(requirement: string): Blueprint {
-  return {
-    requirement,
-    steps: [
-      { id: 'start', label: '开始', next: ['end'] },
-      { id: 'end', label: '结束', next: [] },
-    ],
-  };
+export async function generateBlueprint(requirement: string): Promise<Blueprint> {
+  const apiKey = process.env.OPENAI_API_KEY;
+  const prompt =
+    `请根据以下需求生成一个包含多个步骤的 JSON 数组。` +
+    `每个步骤需包含 id、label、description、inputs、outputs、next 字段。\n需求: ${requirement}`;
+
+  const response = await (globalThis as any).fetch(
+    'https://api.openai.com/v1/chat/completions',
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: 'gpt-4o-mini',
+        messages: [{ role: 'user', content: prompt }],
+        temperature: 0,
+      }),
+    },
+  );
+
+  const data = await response.json();
+  let steps: BlueprintStep[] = [];
+  try {
+    const content = data.choices?.[0]?.message?.content ?? '[]';
+    steps = JSON.parse(content);
+  } catch {
+    steps = [];
+  }
+
+  return { requirement, steps };
 }
 
 export default generateBlueprint;

--- a/src/planner/__tests__/blueprintToDag.test.ts
+++ b/src/planner/__tests__/blueprintToDag.test.ts
@@ -1,10 +1,31 @@
 import { describe, it, expect } from 'vitest';
 import { blueprintToDag } from '../blueprintToDag';
-import { generateBlueprint } from '../../ideas/generateBlueprint';
+import type { Blueprint } from '../../ideas/generateBlueprint';
+
+const blueprint: Blueprint = {
+  requirement: '',
+  steps: [
+    {
+      id: 'start',
+      label: '开始',
+      description: '',
+      inputs: [],
+      outputs: [],
+      next: ['end'],
+    },
+    {
+      id: 'end',
+      label: '结束',
+      description: '',
+      inputs: [],
+      outputs: [],
+      next: [],
+    },
+  ],
+};
 
 describe('blueprintToDag', () => {
   it('将蓝图转换为节点和边', () => {
-    const blueprint = generateBlueprint('');
     const { nodes, edges } = blueprintToDag(blueprint);
     expect(nodes).toHaveLength(2);
     expect(edges).toHaveLength(1);


### PR DESCRIPTION
## Summary
- 接入 OpenAI Chat Completions API，根据需求文本生成蓝图步骤
- 为 BlueprintStep 增加描述、输入、输出等字段
- 调整相关单元测试以适配新结构

## Testing
- `npm test` *(失败：缺少 vitest 命令)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_b_68a7f7649d10832abace5117f684ca0b