### PR TITLE
为 NodePage 添加测试与文档

### DIFF
--- a/docs/node-page.md
+++ b/docs/node-page.md
@@ -1,0 +1,30 @@
+# NodePage 模块
+
+## 使用指南
+
+`setupNodePage` 用于在节点页面中启用流程导入与导出功能：
+
+```ts
+import { setupNodePage } from '../src/nodes/NodePage';
+
+const exportButton = document.getElementById('export-btn') as HTMLButtonElement;
+const importInput = document.getElementById('import-input') as HTMLInputElement;
+
+setupNodePage(exportButton, importInput);
+```
+
+- 点击导出按钮会下载当前流程的 `flow.json` 文件。
+- 在文件选择框中选择 `flow.json` 会导入流程数据。
+
+## API 说明
+
+### `setupNodePage(exportButton: HTMLButtonElement, importInput: HTMLInputElement): void`
+
+为导出按钮和文件输入框注册事件监听，实现流程数据的导出与导入。
+
+| 参数 | 说明 |
+| --- | --- |
+| `exportButton` | 触发导出的按钮元素。 |
+| `importInput` | 选择导入文件的 `<input type="file">` 元素。 |
+
+该函数无返回值。

--- a/src/nodes/__tests__/NodePage.test.ts
+++ b/src/nodes/__tests__/NodePage.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { setupNodePage } from '../NodePage';
+import { exportFlow, importFlow } from '../../shared/storage';
+
+vi.mock('../../shared/storage', () => ({
+  exportFlow: vi.fn(),
+  importFlow: vi.fn(),
+}));
+
+describe('setupNodePage', () => {
+  let exportButton: HTMLButtonElement;
+  let importInput: HTMLInputElement;
+
+  beforeEach(() => {
+    exportButton = document.createElement('button');
+    importInput = document.createElement('input');
+    importInput.type = 'file';
+    vi.clearAllMocks();
+  });
+
+  it('点击导出按钮时应调用 exportFlow 并触发下载', () => {
+    const url = 'blob:mock-url';
+    const createObjectURL = vi.fn(() => url);
+    const revokeObjectURL = vi.fn();
+    const originalCreate = URL.createObjectURL;
+    const originalRevoke = URL.revokeObjectURL;
+    (URL as any).createObjectURL = createObjectURL;
+    (URL as any).revokeObjectURL = revokeObjectURL;
+    const clickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, 'click')
+      .mockImplementation(() => {});
+    (exportFlow as Mock).mockReturnValue('{}');
+
+    setupNodePage(exportButton, importInput);
+    exportButton.click();
+
+    expect(exportFlow).toHaveBeenCalledTimes(1);
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+    expect(revokeObjectURL).toHaveBeenCalledWith(url);
+    expect(clickSpy).toHaveBeenCalled();
+
+    (URL as any).createObjectURL = originalCreate;
+    (URL as any).revokeObjectURL = originalRevoke;
+    clickSpy.mockRestore();
+  });
+
+  it('选择文件后应读取内容并调用 importFlow', async () => {
+    const fileContent = '{"b":2}';
+    const file = {
+      text: () => Promise.resolve(fileContent),
+    } as unknown as File;
+    const fileList = {
+      0: file,
+      length: 1,
+      item: () => file,
+      [Symbol.iterator]: function* () {
+        yield file;
+      },
+    } as unknown as FileList;
+    Object.defineProperty(importInput, 'files', { value: fileList });
+
+    setupNodePage(exportButton, importInput);
+    importInput.dispatchEvent(new Event('change'));
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(importFlow).toHaveBeenCalledWith(fileContent);
+  });
+
+  it('未选择文件时不调用 importFlow', async () => {
+    setupNodePage(exportButton, importInput);
+    importInput.dispatchEvent(new Event('change'));
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(importFlow).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- 为 NodePage 模块编写 Vitest 单元测试，覆盖导入导出功能及边界情况
- 在文档中补充 NodePage 使用指南与 API 说明

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_b_68a7f76abae4832ab7ca14fb6197bdd9