### PR TITLE
feat: 增强运行记录与列表

### DIFF
--- a/src/run-center/index.ts
+++ b/src/run-center/index.ts
@@ -2,13 +2,35 @@ export interface RunRecord {
   id: string;
   input: string;
   output: string;
+  status: 'success' | 'error';
+  duration: number; // ms
   createdAt: number;
 }
 
-const runQueue: RunRecord[] = [];
+const STORAGE_KEY = 'superflow:runs';
+
+function loadRuns(): RunRecord[] {
+  try {
+    const raw = globalThis.localStorage?.getItem(STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as RunRecord[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+const runQueue: RunRecord[] = loadRuns();
+
+function saveRuns(): void {
+  try {
+    globalThis.localStorage?.setItem(STORAGE_KEY, JSON.stringify(runQueue));
+  } catch {
+    // ignore
+  }
+}
 
 export function logRun(record: RunRecord): void {
   runQueue.push(record);
+  saveRuns();
 }
 
 export function getRunRecords(): RunRecord[] {
@@ -17,9 +39,50 @@ export function getRunRecords(): RunRecord[] {
 
 export function clearRunRecords(): void {
   runQueue.length = 0;
+  try {
+    globalThis.localStorage?.removeItem(STORAGE_KEY);
+  } catch {
+    // ignore
+  }
 }
 
-export function RunRecordList() {
-  // TODO: 实现记录列表组件
-  return getRunRecords();
+export function RunRecordList(root: HTMLElement): void {
+  const filterSelect = document.createElement('select');
+  filterSelect.innerHTML = `
+    <option value="all">全部</option>
+    <option value="success">成功</option>
+    <option value="error">失败</option>
+  `;
+
+  const clearButton = document.createElement('button');
+  clearButton.textContent = '清空';
+
+  const list = document.createElement('ul');
+
+  root.append(filterSelect, clearButton, list);
+
+  function render(records: RunRecord[]): void {
+    list.innerHTML = '';
+    records.forEach((r) => {
+      const li = document.createElement('li');
+      li.textContent = `${r.status} | ${r.duration}ms | ${r.input} -> ${r.output}`;
+      list.append(li);
+    });
+  }
+
+  function update(): void {
+    const filter = filterSelect.value;
+    const records = getRunRecords().filter((r) =>
+      filter === 'all' ? true : r.status === filter
+    );
+    render(records);
+  }
+
+  filterSelect.addEventListener('change', update);
+  clearButton.addEventListener('click', () => {
+    clearRunRecords();
+    update();
+  });
+
+  update();
 }

--- a/src/run-center/run-center.test.ts
+++ b/src/run-center/run-center.test.ts
@@ -1,23 +1,95 @@
-import { describe, it, expect, beforeEach } from 'vitest';
-import { logRun, getRunRecords, clearRunRecords, type RunRecord } from './index';
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { logRun, getRunRecords, clearRunRecords, RunRecordList, type RunRecord } from './index';
+
+declare const global: { localStorage: Storage };
 
 describe('run-center', () => {
+  let store: Record<string, string>;
+  let mockStorage: Storage;
+
   beforeEach(() => {
+    store = {};
+    mockStorage = {
+      getItem: vi.fn((key: string) => (key in store ? store[key] : null)),
+      setItem: vi.fn((key: string, value: string) => {
+        store[key] = value;
+      }),
+      removeItem: vi.fn((key: string) => {
+        delete store[key];
+      }),
+      clear: vi.fn(() => {
+        store = {};
+      }),
+      key: vi.fn((index: number) => Object.keys(store)[index] ?? null),
+      get length() {
+        return Object.keys(store).length;
+      }
+    } as Storage;
+
+    vi.stubGlobal('localStorage', mockStorage);
     clearRunRecords();
   });
 
-  it('logs and retrieves records', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('logs, retrieves and persists records', () => {
     const record: RunRecord = {
       id: '1',
       input: 'input data',
       output: 'output data',
+      status: 'success',
+      duration: 100,
       createdAt: Date.now(),
     };
 
     logRun(record);
 
+    expect(mockStorage.setItem).toHaveBeenCalledWith(
+      'superflow:runs',
+      JSON.stringify([record])
+    );
+
     const records = getRunRecords();
     expect(records).toHaveLength(1);
     expect(records[0]).toEqual(record);
+  });
+
+  it('renders, filters and clears records list', () => {
+    const now = Date.now();
+    logRun({
+      id: '1',
+      input: 'a',
+      output: 'b',
+      status: 'success',
+      duration: 10,
+      createdAt: now,
+    });
+    logRun({
+      id: '2',
+      input: 'c',
+      output: 'd',
+      status: 'error',
+      duration: 20,
+      createdAt: now,
+    });
+
+    const root = document.createElement('div');
+    RunRecordList(root);
+
+    const list = root.querySelector('ul')!;
+    expect(list.children.length).toBe(2);
+
+    const select = root.querySelector('select')!;
+    select.value = 'success';
+    select.dispatchEvent(new Event('change'));
+    expect(list.children.length).toBe(1);
+
+    const button = root.querySelector('button')!;
+    button.click();
+    expect(list.children.length).toBe(0);
+    expect(mockStorage.removeItem).toHaveBeenCalledWith('superflow:runs');
   });
 });


### PR DESCRIPTION
## Summary
- 扩展运行记录结构，添加状态与耗时并持久化到 localStorage
- 新增运行记录列表组件，支持筛选与清空
- 增强测试覆盖运行记录持久化及列表操作

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: Parsing error: Unexpected token interface)*

------
https://chatgpt.com/codex/tasks/task_b_68a7f76952a8832abb4efcae8c44bb80