### PR TITLE
feat: enhance blueprint DAG

### DIFF
--- a/src/ideas/generateBlueprint.ts
+++ b/src/ideas/generateBlueprint.ts
@@ -1,6 +1,7 @@
 export interface BlueprintStep {
   id: string;
   label: string;
+  type?: string;
   next: string[];
 }
 
@@ -16,8 +17,8 @@ export function generateBlueprint(requirement: string): Blueprint {
   return {
     requirement,
     steps: [
-      { id: 'start', label: '开始', next: ['end'] },
-      { id: 'end', label: '结束', next: [] },
+      { id: 'start', label: '开始', type: 'input', next: ['end'] },
+      { id: 'end', label: '结束', type: 'output', next: [] },
     ],
   };
 }

--- a/src/planner/__tests__/blueprintToDag.test.ts
+++ b/src/planner/__tests__/blueprintToDag.test.ts
@@ -10,4 +10,36 @@ describe('blueprintToDag', () => {
     expect(edges).toHaveLength(1);
     expect(edges[0]).toEqual({ id: 'start-end', source: 'start', target: 'end' });
   });
+
+  it('支持节点类型、自动布局及多入口/出口', () => {
+    const blueprint = {
+      requirement: '',
+      steps: [
+        { id: 'in1', label: '输入1', type: 'input', next: ['core'] },
+        { id: 'in2', label: '输入2', type: 'input', next: ['core'] },
+        { id: 'core', label: '处理', type: 'process', next: ['out1', 'out2'] },
+        { id: 'out1', label: '输出1', type: 'output', next: [] },
+        { id: 'out2', label: '输出2', type: 'output', next: [] },
+      ],
+    } as const;
+    const { nodes, edges } = blueprintToDag(blueprint);
+    const nodeMap = Object.fromEntries(nodes.map((n) => [n.id, n]));
+    expect(nodeMap.in1.type).toBe('input');
+    expect(nodeMap.in2.position).toEqual({ x: 0, y: 100 });
+    expect(nodeMap.core.position).toEqual({ x: 200, y: 0 });
+    expect(nodeMap.out1.position).toEqual({ x: 400, y: 0 });
+    expect(nodeMap.out2.position).toEqual({ x: 400, y: 100 });
+    expect(edges).toHaveLength(4);
+  });
+
+  it('检测环路并抛出错误', () => {
+    const blueprint = {
+      requirement: '',
+      steps: [
+        { id: 'a', label: 'A', type: 'task', next: ['b'] },
+        { id: 'b', label: 'B', type: 'task', next: ['a'] },
+      ],
+    } as const;
+    expect(() => blueprintToDag(blueprint)).toThrow();
+  });
 });

--- a/src/planner/blueprintToDag.ts
+++ b/src/planner/blueprintToDag.ts
@@ -2,6 +2,7 @@ import type { Blueprint } from '../ideas/generateBlueprint';
 
 export interface DagNode {
   id: string;
+  type?: string;
   data: { label: string };
   position: { x: number; y: number };
 }
@@ -21,18 +22,64 @@ export interface Dag {
  * 将蓝图转换为可用于渲染的 DAG 结构。
  */
 export function blueprintToDag(blueprint: Blueprint): Dag {
-  const nodes: DagNode[] = blueprint.steps.map((step, index) => ({
-    id: step.id,
-    data: { label: step.label },
-    position: { x: 0, y: index * 100 },
-  }));
-
-  const edges: DagEdge[] = [];
+  const stepMap = new Map(blueprint.steps.map((s) => [s.id, s]));
+  const indegree = new Map<string, number>();
+  for (const step of blueprint.steps) {
+    indegree.set(step.id, 0);
+  }
   for (const step of blueprint.steps) {
     for (const target of step.next) {
-      edges.push({ id: `${step.id}-${target}`, source: step.id, target });
+      if (!stepMap.has(target)) {
+        throw new Error(`未知节点: ${target}`);
+      }
+      indegree.set(target, (indegree.get(target) ?? 0) + 1);
     }
   }
+
+  const queue: string[] = [];
+  for (const [id, deg] of indegree) {
+    if (deg === 0) queue.push(id);
+  }
+
+  const layers: string[][] = [];
+  const edges: DagEdge[] = [];
+  const visited = new Set<string>();
+
+  while (queue.length > 0) {
+    const layerSize = queue.length;
+    const layer: string[] = [];
+    for (let i = 0; i < layerSize; i++) {
+      const id = queue.shift()!;
+      layer.push(id);
+      visited.add(id);
+      const step = stepMap.get(id)!;
+      for (const target of step.next) {
+        edges.push({ id: `${id}-${target}`, source: id, target });
+        indegree.set(target, (indegree.get(target)! - 1));
+        if (indegree.get(target) === 0) {
+          queue.push(target);
+        }
+      }
+    }
+    layers.push(layer);
+  }
+
+  if (visited.size !== blueprint.steps.length) {
+    throw new Error('蓝图包含环路');
+  }
+
+  const nodes: DagNode[] = [];
+  layers.forEach((layer, xIndex) => {
+    layer.forEach((id, yIndex) => {
+      const step = stepMap.get(id)!;
+      nodes.push({
+        id: step.id,
+        type: step.type,
+        data: { label: step.label },
+        position: { x: xIndex * 200, y: yIndex * 100 },
+      });
+    });
+  });
 
   return { nodes, edges };
 }


### PR DESCRIPTION
## Summary
- support node type, auto-layout, and multi-entry/exit in `blueprintToDag`
- add cycle detection and tests for common topologies

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_b_68a7f7651594832aa41119395c69d460