### PR TITLE
重命名 Web 组件标签为 workflow-* 并更新文档

### DIFF
--- a/docs/node-page.md
+++ b/docs/node-page.md
@@ -17,6 +17,24 @@ setupNodePage(exportButton, importInput);
 - 在文件选择框中选择 `flow.json` 会导入流程数据。
 - 导入后输入框会自动清空，方便再次选择同一文件。
 
+## Web Component
+
+除函数方式外，还可以直接使用自定义元素 `<workflow-node>`：
+
+```html
+<workflow-node id="page"></workflow-node>
+<script type="module">
+  import 'superflow/nodes/NodePage.js';
+
+  const page = document.getElementById('page');
+  page.addEventListener('flow-import', (e) => {
+    console.log('imported', e.detail);
+  });
+</script>
+```
+
+该组件会触发 `flow-export` 与 `flow-import` 两个事件。
+
 ## API 说明
 
 ### `setupNodePage(exportButton: HTMLButtonElement, importInput: HTMLInputElement): void`

--- a/public/embed.html
+++ b/public/embed.html
@@ -5,8 +5,8 @@
     <title>Superflow 嵌入示例</title>
   </head>
   <body>
-    <flow-canvas id="canvas"></flow-canvas>
-    <node-page id="page"></node-page>
+    <workflow-flow id="canvas"></workflow-flow>
+    <workflow-node id="page"></workflow-node>
     <script type="module">
       import '../dist/flow/FlowCanvas.js';
       import '../dist/nodes/NodePage.js';

--- a/src/flow/FlowCanvas.ts
+++ b/src/flow/FlowCanvas.ts
@@ -47,6 +47,6 @@ export class FlowCanvasElement extends HTMLElement {
   }
 }
 
-customElements.define('flow-canvas', FlowCanvasElement);
+customElements.define('workflow-flow', FlowCanvasElement);
 
 export default FlowCanvasElement;

--- a/src/nodes/NodePage.ts
+++ b/src/nodes/NodePage.ts
@@ -164,6 +164,6 @@ export class NodePageElement extends HTMLElement {
   };
 }
 
-customElements.define('node-page', NodePageElement);
+customElements.define('workflow-node', NodePageElement);
 
 export default NodePageElement;


### PR DESCRIPTION
## Summary
- 将 NodePage Web Component 重命名为 `<workflow-node>`
- 将 FlowCanvas Web Component 重命名为 `<workflow-flow>`
- 更新嵌入示例和文档以使用新标签

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_68a8245f07cc832aa55b80592ac59baf