### PR TITLE
feat: 添加 IdeasPage 页面

### DIFF
--- a/src/ideas/IdeasPage.ts
+++ b/src/ideas/IdeasPage.ts
@@ -1,0 +1,52 @@
+import FlowCanvasElement from '../flow/FlowCanvas';
+import { generateBlueprint, type Blueprint } from './generateBlueprint';
+import { blueprintToDag } from '../planner/blueprintToDag';
+
+/**
+ * 入口页面 Web Component。
+ * 提供需求输入框，生成蓝图后渲染流程并派发事件。
+ */
+export class IdeasPageElement extends HTMLElement {
+  private textarea: HTMLTextAreaElement;
+  private button: HTMLButtonElement;
+  private canvas: FlowCanvasElement;
+
+  constructor() {
+    super();
+    const shadow = this.attachShadow({ mode: 'open' });
+
+    this.textarea = document.createElement('textarea');
+    this.button = document.createElement('button');
+    this.button.textContent = '生成流程';
+    this.canvas = document.createElement('flow-canvas') as FlowCanvasElement;
+    this.canvas.style.display = 'none';
+
+    shadow.append(this.textarea, this.button, this.canvas);
+  }
+
+  connectedCallback(): void {
+    this.button.addEventListener('click', this.handleGenerate);
+  }
+
+  disconnectedCallback(): void {
+    this.button.removeEventListener('click', this.handleGenerate);
+  }
+
+  private handleGenerate = async (): Promise<void> => {
+    const requirement = this.textarea.value.trim();
+    if (!requirement) return;
+    const blueprint: Blueprint = await generateBlueprint(requirement);
+    const dag = blueprintToDag(blueprint);
+    this.canvas.blueprint = blueprint;
+    this.canvas.style.display = 'block';
+    this.dispatchEvent(
+      new CustomEvent('blueprint-generated', {
+        detail: { blueprint, dag },
+      }),
+    );
+  };
+}
+
+customElements.define('ideas-page', IdeasPageElement);
+
+export default IdeasPageElement;

--- a/src/ideas/__tests__/IdeasPage.test.ts
+++ b/src/ideas/__tests__/IdeasPage.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import IdeasPageElement from '../IdeasPage';
+
+function nextTick() {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe('IdeasPageElement', () => {
+  it('生成蓝图后派发事件并渲染流程', async () => {
+    const el = new IdeasPageElement();
+    document.body.appendChild(el);
+    const textarea = el.shadowRoot!.querySelector('textarea')!;
+    const button = el.shadowRoot!.querySelector('button')!;
+
+    textarea.value = '测试需求';
+    const eventPromise = new Promise<CustomEvent>((resolve) =>
+      el.addEventListener('blueprint-generated', (e) => resolve(e as CustomEvent), {
+        once: true,
+      }),
+    );
+    button.click();
+    const evt = await eventPromise;
+    expect(evt.detail.blueprint.requirement).toBe('测试需求');
+    await nextTick();
+    const canvas = el.shadowRoot!.querySelector('flow-canvas') as any;
+    expect(canvas.blueprint.requirement).toBe('测试需求');
+    document.body.removeChild(el);
+  });
+});

--- a/src/ideas/index.ts
+++ b/src/ideas/index.ts
@@ -1,1 +1,2 @@
 export * from './generateBlueprint';
+export * from './IdeasPage';


### PR DESCRIPTION
## Summary
- 新增 `IdeasPage` 页面，输入需求并生成蓝图
- 通过 `blueprintToDag` 转换后交由 `FlowCanvas` 渲染
- 增加页面测试并在导出入口暴露组件

## Testing
- `npm test` *(fail: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a8245fb604832aa25e0c70dd4cf3a0