### PR TITLE
处理 importFlow JSON 解析错误并添加测试

### DIFF
--- a/src/shared/__tests__/storage.test.ts
+++ b/src/shared/__tests__/storage.test.ts
@@ -52,4 +52,11 @@ describe('storage', () => {
     importFlow(json);
     expect(loadFlow()).toEqual({ b: 2 });
   });
+
+  it('returns null and does not write on invalid JSON', () => {
+    const result = importFlow('invalid');
+    expect(result).toBeNull();
+    expect(mockStorage.setItem).not.toHaveBeenCalled();
+    expect(mockStorage.length).toBe(0);
+  });
 });

--- a/src/shared/storage.ts
+++ b/src/shared/storage.ts
@@ -23,9 +23,13 @@ export function importFlow(
   json: string,
   storage: Storage = globalThis.localStorage
 ): unknown {
-  const flow = JSON.parse(json);
-  saveFlow(flow, storage);
-  return flow;
+  try {
+    const flow = JSON.parse(json);
+    saveFlow(flow, storage);
+    return flow;
+  } catch {
+    return null;
+  }
 }
 
 export default { saveFlow, loadFlow, exportFlow, importFlow };


### PR DESCRIPTION
## Summary
- 捕获 `importFlow` 中 `JSON.parse` 的异常并返回 null
- 新增无效 JSON 导入的测试用例，确保不写入 localStorage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a8335ca0c0832a9c17e55936f2a0ae