### PR TITLE
test: cover generateBlueprint fallback cases

### DIFF
--- a/src/ideas/__tests__/generateBlueprint.test.ts
+++ b/src/ideas/__tests__/generateBlueprint.test.ts
@@ -20,8 +20,32 @@ const mockSteps = [
   },
 ];
 
+const defaultSteps = [
+  {
+    id: 'start',
+    label: '开始',
+    type: 'input',
+    description: '流程开始节点',
+    inputs: [],
+    outputs: ['data'],
+    next: ['end'],
+  },
+  {
+    id: 'end',
+    label: '结束',
+    type: 'output',
+    description: '流程结束节点',
+    inputs: ['data'],
+    outputs: [],
+    next: [],
+  },
+];
+
+const originalEnv = process.env.OPENAI_API_KEY;
+
 describe('generateBlueprint', () => {
   beforeEach(() => {
+    process.env.OPENAI_API_KEY = originalEnv;
     vi.stubGlobal(
       'fetch',
       vi.fn(async () => ({
@@ -42,6 +66,7 @@ describe('generateBlueprint', () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    process.env.OPENAI_API_KEY = originalEnv;
   });
 
   it('返回包含描述和输入输出的蓝图', async () => {
@@ -50,5 +75,30 @@ describe('generateBlueprint', () => {
     expect(blueprint.steps[0]).toHaveProperty('description');
     expect(Array.isArray(blueprint.steps[0].inputs)).toBe(true);
     expect(Array.isArray(blueprint.steps[0].outputs)).toBe(true);
+  });
+
+  it('在未设置 OPENAI_API_KEY 时返回默认蓝图', async () => {
+    delete process.env.OPENAI_API_KEY;
+    const blueprint = await generateBlueprint('缺少 key');
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(blueprint).toEqual({ requirement: '缺少 key', steps: defaultSteps });
+  });
+
+  it('当 fetch 抛出错误时返回默认蓝图', async () => {
+    process.env.OPENAI_API_KEY = 'test-key';
+    (global.fetch as any).mockRejectedValueOnce(new Error('network'));
+    const blueprint = await generateBlueprint('网络异常');
+    expect(global.fetch).toHaveBeenCalled();
+    expect(blueprint).toEqual({ requirement: '网络异常', steps: defaultSteps });
+  });
+
+  it('当 fetch 返回非 JSON 时返回默认蓝图', async () => {
+    process.env.OPENAI_API_KEY = 'test-key';
+    (global.fetch as any).mockResolvedValueOnce({
+      json: () => Promise.reject(new Error('invalid json')),
+    });
+    const blueprint = await generateBlueprint('无效响应');
+    expect(global.fetch).toHaveBeenCalled();
+    expect(blueprint).toEqual({ requirement: '无效响应', steps: defaultSteps });
   });
 });


### PR DESCRIPTION
## Summary
- 增加默认蓝图常量与环境变量备份
- 补充未设置 OPENAI_API_KEY、fetch 抛错与返回非 JSON 的测试

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a83342a83c832ab262cb40ffd1adf0