### PR TITLE
feat: 支持只读流程画布

### DIFF
--- a/src/flow/FlowCanvas.ts
+++ b/src/flow/FlowCanvas.ts
@@ -57,6 +57,7 @@ export class FlowCanvasElement extends HTMLElement {
     } else {
       this.removeAttribute('readonly');
     }
+    this.render();
   }
 
   get dag(): Dag | null {
@@ -107,10 +108,15 @@ export class FlowCanvasElement extends HTMLElement {
       this._dag = null;
       return;
     }
-    this.flow = renderFlow(this._blueprint as any, this.container, (dag) => {
-      this._dag = dag;
-      this.dispatchEvent(new CustomEvent('dag-change', { detail: dag }));
-    });
+    this.flow = renderFlow(
+      this._blueprint as any,
+      this.container,
+      (dag) => {
+        this._dag = dag;
+        this.dispatchEvent(new CustomEvent('dag-change', { detail: dag }));
+      },
+      this._readonly
+    );
     this.dispatchEvent(new CustomEvent('flow-render', { detail: this._dag }));
   }
 }

--- a/src/flow/renderFlow.tsx
+++ b/src/flow/renderFlow.tsx
@@ -24,18 +24,20 @@ export interface FlowInstance {
 }
 
 // React组件来渲染流程图
-function FlowComponent({ 
-  initialNodes, 
-  initialEdges, 
-  onNodesChange, 
-  onEdgesChange, 
-  onConnect 
+function FlowComponent({
+  initialNodes,
+  initialEdges,
+  onNodesChange,
+  onEdgesChange,
+  onConnect,
+  readonly
 }: {
   initialNodes: Node[];
   initialEdges: Edge[];
   onNodesChange: (nodes: Node[]) => void;
   onEdgesChange: (edges: Edge[]) => void;
   onConnect: (connection: Connection) => void;
+  readonly: boolean;
 }) {
   const [nodes, setNodes, onNodesChangeInternal] = useNodesState(initialNodes);
   const [edges, setEdges, onEdgesChangeInternal] = useEdgesState(initialEdges);
@@ -65,6 +67,10 @@ function FlowComponent({
         onNodesChange={handleNodesChange}
         onEdgesChange={handleEdgesChange}
         onConnect={handleConnect}
+        nodesDraggable={!readonly}
+        nodesConnectable={!readonly}
+        elementsSelectable={!readonly}
+        connectOnClick={!readonly}
         fitView
         attributionPosition="bottom-left"
       >
@@ -89,7 +95,8 @@ function FlowComponent({
 export function renderFlow(
   blueprint: Parameters<typeof blueprintToDag>[0],
   container: HTMLElement,
-  onChange?: (dag: Dag) => void
+  onChange?: (dag: Dag) => void,
+  readonly = false
 ): FlowInstance {
   let { nodes, edges } = blueprintToDag(blueprint);
   const root: Root = createRoot(container);
@@ -168,6 +175,7 @@ export function renderFlow(
             emit();
           }
         }}
+        readonly={readonly}
       />
     );
   };


### PR DESCRIPTION
## Summary
- FlowCanvas 将 `_readonly` 作为参数传入 `renderFlow`
- `renderFlow` 根据 `readonly` 设置不可编辑的 ReactFlow 属性
- 切换 `readonly` 时重新渲染使画布生效

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check` *(失败: TS6133, TS2322 等)*

------
https://chatgpt.com/codex/tasks/task_b_68a877e3ed18832a8a46199431968378