### PR TITLE
feat: 支持节点和连线右键删除

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,8 @@
     <title>Superflow - 工作流编辑器</title>
     <style>
       body {
-        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+        font-family:
+          -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
         margin: 0;
         padding: 20px;
         background-color: #f5f5f5;
@@ -16,7 +17,7 @@
         margin: 0 auto;
         background: white;
         border-radius: 8px;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
         padding: 20px;
       }
       h1 {
@@ -54,12 +55,12 @@
   <body>
     <div class="container">
       <h1>Superflow 工作流编辑器</h1>
-      
+
       <div class="section">
         <h2>流程画布</h2>
         <workflow-flow id="canvas"></workflow-flow>
       </div>
-      
+
       <div class="section">
         <h2>节点页面</h2>
         <workflow-node id="page"></workflow-node>
@@ -75,7 +76,7 @@
       const canvas = document.getElementById('canvas');
       if (canvas) {
         canvas.blueprint = {
-          requirement: "数据处理工作流示例",
+          requirement: '数据处理工作流示例',
           steps: [
             {
               id: 'start',
@@ -84,7 +85,7 @@
               description: '工作流开始节点',
               inputs: [],
               outputs: ['data'],
-              next: ['collect']
+              next: ['collect'],
             },
             {
               id: 'collect',
@@ -93,7 +94,7 @@
               description: '收集输入数据',
               inputs: ['data'],
               outputs: ['raw_data'],
-              next: ['process']
+              next: ['process'],
             },
             {
               id: 'process',
@@ -102,7 +103,7 @@
               description: '处理和清洗数据',
               inputs: ['raw_data'],
               outputs: ['processed_data'],
-              next: ['validate', 'analyze']
+              next: ['validate', 'analyze'],
             },
             {
               id: 'validate',
@@ -111,7 +112,7 @@
               description: '验证数据完整性',
               inputs: ['processed_data'],
               outputs: ['validated_data'],
-              next: ['report']
+              next: ['report'],
             },
             {
               id: 'analyze',
@@ -120,7 +121,7 @@
               description: '分析数据趋势',
               inputs: ['processed_data'],
               outputs: ['analysis_result'],
-              next: ['report']
+              next: ['report'],
             },
             {
               id: 'report',
@@ -129,7 +130,7 @@
               description: '生成分析报告',
               inputs: ['validated_data', 'analysis_result'],
               outputs: ['report'],
-              next: ['notify']
+              next: ['notify'],
             },
             {
               id: 'notify',
@@ -138,7 +139,7 @@
               description: '发送完成通知',
               inputs: ['report'],
               outputs: ['notification'],
-              next: ['end']
+              next: ['end'],
             },
             {
               id: 'end',
@@ -147,9 +148,9 @@
               description: '工作流结束',
               inputs: ['notification'],
               outputs: [],
-              next: []
-            }
-          ]
+              next: [],
+            },
+          ],
         };
       }
 
@@ -159,7 +160,7 @@
         page.addEventListener('flow-import', (e) => {
           console.log('Flow imported:', e.detail);
         });
-        
+
         page.addEventListener('run', (e) => {
           console.log('Node run:', e.detail);
         });

--- a/src/flow/renderFlow.tsx
+++ b/src/flow/renderFlow.tsx
@@ -8,7 +8,9 @@ import ReactFlow, {
   addEdge,
   Connection,
   Edge,
-  Node
+  Node,
+  BackgroundVariant,
+  MarkerType,
 } from 'reactflow';
 import 'reactflow/dist/style.css';
 import type { Dag, DagNode, DagEdge } from '../planner/blueprintToDag';
@@ -42,7 +44,7 @@ function FlowComponent({
   onDeleteNode: (id: string) => void;
   onDeleteEdge: (id: string) => void;
 }) {
-  const [nodes, setNodes, onNodesChangeInternal] = useNodesState(initialNodes);
+  const [nodes, , onNodesChangeInternal] = useNodesState(initialNodes);
   const [edges, setEdges, onEdgesChangeInternal] = useEdgesState(initialEdges);
 
   const handleNodesChange = (changes: any) => {
@@ -107,7 +109,7 @@ function FlowComponent({
           nodeStrokeWidth={3}
           maskColor="rgba(0, 0, 0, 0.2)"
         />
-        <Background variant="dots" gap={12} size={1} />
+        <Background variant={BackgroundVariant.Dots} gap={12} size={1} />
       </ReactFlow>
     </div>
   );
@@ -124,11 +126,10 @@ export function renderFlow(
   // 转换为ReactFlow格式的节点和边
   const convertToReactFlowFormat = () => {
     const reactFlowNodes: Node[] = nodes.map(node => ({
-      ...node,
-      data: { 
-        label: node.data?.label || node.id,
-        ...node.data 
-      },
+      id: node.id,
+      type: node.type,
+      position: node.position,
+      data: { label: node.data?.label || node.id },
       style: {
         background: '#fff',
         border: '2px solid #333',
@@ -138,20 +139,21 @@ export function renderFlow(
         color: '#333',
         minWidth: 100,
         textAlign: 'center',
-        ...node.style
-      }
+      },
     }));
 
     const reactFlowEdges: Edge[] = edges.map(edge => ({
-      ...edge,
+      id: edge.id,
+      source: edge.source,
+      target: edge.target,
       type: 'smoothstep',
       style: { stroke: '#333', strokeWidth: 2 },
       markerEnd: {
-        type: 'arrowclosed',
+        type: MarkerType.ArrowClosed,
         width: 20,
         height: 20,
         color: '#333',
-      }
+      },
     }));
 
     return { nodes: reactFlowNodes, edges: reactFlowEdges };
@@ -190,8 +192,7 @@ export function renderFlow(
           nodes = updatedNodes.map(node => ({
             id: node.id,
             position: node.position,
-            data: node.data,
-            style: node.style
+            data: node.data as { label: string },
           }));
           emit();
         }}

--- a/src/flow/renderFlow.tsx
+++ b/src/flow/renderFlow.tsx
@@ -34,7 +34,7 @@ function FlowComponent({
   onEdgesChange,
   onConnect,
   onDeleteNode,
-  onDeleteEdge
+  onDeleteEdge,
 }: {
   initialNodes: Node[];
   initialEdges: Edge[];
@@ -64,20 +64,14 @@ function FlowComponent({
     onEdgesChange(newEdge);
   };
 
-  const handleNodeContextMenu = (
-    event: MouseEvent,
-    node: Node
-  ) => {
+  const handleNodeContextMenu = (event: MouseEvent, node: Node) => {
     event.preventDefault();
     if (window.confirm('确认删除该节点？')) {
       onDeleteNode(node.id);
     }
   };
 
-  const handleEdgeContextMenu = (
-    event: MouseEvent,
-    edge: Edge
-  ) => {
+  const handleEdgeContextMenu = (event: MouseEvent, edge: Edge) => {
     event.preventDefault();
     if (window.confirm('确认删除该连线？')) {
       onDeleteEdge(edge.id);
@@ -98,7 +92,7 @@ function FlowComponent({
         attributionPosition="bottom-left"
       >
         <Controls />
-        <MiniMap 
+        <MiniMap
           style={{
             height: 120,
             width: 200,
@@ -125,7 +119,7 @@ export function renderFlow(
 
   // 转换为ReactFlow格式的节点和边
   const convertToReactFlowFormat = () => {
-    const reactFlowNodes: Node[] = nodes.map(node => ({
+    const reactFlowNodes: Node[] = nodes.map((node) => ({
       id: node.id,
       type: node.type,
       position: node.position,
@@ -142,7 +136,7 @@ export function renderFlow(
       },
     }));
 
-    const reactFlowEdges: Edge[] = edges.map(edge => ({
+    const reactFlowEdges: Edge[] = edges.map((edge) => ({
       id: edge.id,
       source: edge.source,
       target: edge.target,
@@ -159,7 +153,8 @@ export function renderFlow(
     return { nodes: reactFlowNodes, edges: reactFlowEdges };
   };
 
-  let { nodes: reactFlowNodes, edges: reactFlowEdges } = convertToReactFlowFormat();
+  let { nodes: reactFlowNodes, edges: reactFlowEdges } =
+    convertToReactFlowFormat();
 
   const emit = () => {
     onChange?.({ nodes, edges });
@@ -189,7 +184,7 @@ export function renderFlow(
         initialNodes={reactFlowNodes}
         initialEdges={reactFlowEdges}
         onNodesChange={(updatedNodes) => {
-          nodes = updatedNodes.map(node => ({
+          nodes = updatedNodes.map((node) => ({
             id: node.id,
             position: node.position,
             data: node.data as { label: string },
@@ -197,17 +192,21 @@ export function renderFlow(
           emit();
         }}
         onEdgesChange={(updatedEdges) => {
-          edges = updatedEdges.map(edge => ({
+          edges = updatedEdges.map((edge) => ({
             id: edge.id,
             source: edge.source,
-            target: edge.target
+            target: edge.target,
           }));
           emit();
         }}
         onConnect={(connection) => {
           if (connection.source && connection.target) {
             const id = `${connection.source}-${connection.target}-${Date.now()}`;
-            const newEdge = { id, source: connection.source, target: connection.target };
+            const newEdge = {
+              id,
+              source: connection.source,
+              target: connection.target,
+            };
             edges = [...edges, newEdge];
             const converted = convertToReactFlowFormat();
             reactFlowEdges = converted.edges;


### PR DESCRIPTION
## Summary
- 为 ReactFlow 节点和连线添加右键菜单，确认后删除
- 删除后重新渲染并触发 emit，保持外部 Dag 同步

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a877e2a2f0832aa84c106b538302eb