### PR TITLE
feat: 更新节点与连线变更逻辑

### DIFF
--- a/src/flow/renderFlow.tsx
+++ b/src/flow/renderFlow.tsx
@@ -1,11 +1,13 @@
 import { createRoot, Root } from 'react-dom/client';
-import ReactFlow, { 
-  Controls, 
-  Background, 
+import ReactFlow, {
+  Controls,
+  Background,
   MiniMap,
   useNodesState,
   useEdgesState,
   addEdge,
+  applyNodeChanges,
+  applyEdgeChanges,
   Connection,
   Edge,
   Node
@@ -37,17 +39,19 @@ function FlowComponent({
   onEdgesChange: (edges: Edge[]) => void;
   onConnect: (connection: Connection) => void;
 }) {
-  const [nodes, setNodes, onNodesChangeInternal] = useNodesState(initialNodes);
-  const [edges, setEdges, onEdgesChangeInternal] = useEdgesState(initialEdges);
+  const [nodes, setNodes] = useNodesState(initialNodes);
+  const [edges, setEdges] = useEdgesState(initialEdges);
 
   const handleNodesChange = (changes: any) => {
-    onNodesChangeInternal(changes);
-    onNodesChange(nodes);
+    const updatedNodes = applyNodeChanges(changes, nodes);
+    setNodes(updatedNodes);
+    onNodesChange(updatedNodes);
   };
 
   const handleEdgesChange = (changes: any) => {
-    onEdgesChangeInternal(changes);
-    onEdgesChange(edges);
+    const updatedEdges = applyEdgeChanges(changes, edges);
+    setEdges(updatedEdges);
+    onEdgesChange(updatedEdges);
   };
 
   const handleConnect = (connection: Connection) => {


### PR DESCRIPTION
## Summary
- 使用 applyNodeChanges/applyEdgeChanges 计算最新节点与连线
- 在回调前调用 setNodes/setEdges 保证父组件获取最新布局

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check` *(fails: TS errors remain)*

------
https://chatgpt.com/codex/tasks/task_b_68a877df0ff8832a82d37353936997d5