### PR TITLE
feat: 完善共享类型与序列化测试

### DIFF
--- a/src/shared/types/__tests__/serialization.test.ts
+++ b/src/shared/types/__tests__/serialization.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ExecRequestSchema, ExecEventSchema, NodeContext } from '../runtime';
+import { RunRecord, LogRecord, VersionRecord } from '../storage';
+import { createError } from '../error';
+
+const ULID = '01ARZ3NDEKTSV4RRFFQ69G5FAV';
+
+describe('类型校验与 JSON 序列化', () => {
+  it('ExecRequest 序列化/反序列化', () => {
+    const req = {
+      kind: 'EXEC',
+      runId: ULID,
+      nodeId: 'node-1',
+      flowId: 'flow-1',
+      code: 'export const handler = () => {};',
+      language: 'js' as const,
+      input: { foo: 1 },
+      controls: { timeoutMs: 1000, retries: 2 },
+      env: { A: '1' },
+      capabilities: ['test'],
+    };
+    const json = JSON.stringify(req);
+    const parsed = ExecRequestSchema.parse(JSON.parse(json));
+    expect(parsed).toEqual(req);
+  });
+
+  it('ExecEvent 序列化/反序列化', () => {
+    const event = {
+      kind: 'RESULT' as const,
+      runId: ULID,
+      ts: Date.now(),
+      durationMs: 10,
+      output: { ok: true },
+    };
+    const json = JSON.stringify(event);
+    const parsed = ExecEventSchema.parse(JSON.parse(json));
+    expect(parsed).toEqual(event);
+  });
+
+  it('NodeContext 类型', () => {
+    const ctx: NodeContext = {
+      signal: new AbortController().signal,
+      logger: {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      },
+      env: { A: '1' },
+      kv: {
+        get: async () => null,
+        put: async () => {},
+        del: async () => {},
+      },
+      traceId: 'trace-1',
+    };
+    expect(ctx.logger.info).toBeDefined();
+  });
+
+  it('RunRecord 序列化/反序列化', () => {
+    const run: RunRecord = {
+      id: ULID,
+      createdAt: 1,
+      updatedAt: 1,
+      flowId: 'flow-1',
+      startedAt: 1,
+      status: 'pending',
+      traceId: 'trace-1',
+    };
+    const json = JSON.stringify(run);
+    const parsed = JSON.parse(json) as RunRecord;
+    expect(parsed).toEqual(run);
+  });
+
+  it('LogRecord 序列化/反序列化', () => {
+    const log: LogRecord = {
+      id: ULID,
+      createdAt: 1,
+      updatedAt: 1,
+      runId: ULID,
+      timestamp: 1,
+      level: 'info',
+      event: 'test',
+      traceId: 'trace-1',
+    };
+    const json = JSON.stringify(log);
+    const parsed = JSON.parse(json) as LogRecord;
+    expect(parsed).toEqual(log);
+  });
+
+  it('VersionRecord 序列化/反序列化', () => {
+    const version: VersionRecord = {
+      id: ULID,
+      createdAt: 1,
+      updatedAt: 1,
+      nodeId: 'node-1',
+      author: 'me',
+      message: 'msg',
+      diff: 'diff',
+    };
+    const json = JSON.stringify(version);
+    const parsed = JSON.parse(json) as VersionRecord;
+    expect(parsed).toEqual(version);
+  });
+
+  it('错误模型 序列化/反序列化', () => {
+    const err = createError('RUNTIME_ERROR', 'fail', { foo: 'bar' });
+    const json = JSON.stringify(err);
+    const parsed = JSON.parse(json) as ReturnType<typeof createError>;
+    expect(parsed).toMatchObject({
+      name: 'SuperflowError',
+      message: 'fail',
+      code: 'RUNTIME_ERROR',
+    });
+    expect((parsed as any).cause.foo).toBe('bar');
+  });
+});

--- a/src/shared/types/storage.ts
+++ b/src/shared/types/storage.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
-import { BaseEntity } from './base';
+import { BaseEntity, TraceId } from './base';
+import { RunStatus, LogLevel } from './runtime';
+import type { AppError } from './error';
 
 export const DB_VERSION = 1;
 
@@ -22,6 +24,26 @@ export interface KVRecord extends BaseEntity {
   key: string;
   value: unknown;
   expiresAt?: number;
+}
+
+export interface RunRecord extends BaseEntity {
+  flowId: string;
+  startedAt: number;
+  finishedAt?: number;
+  status: RunStatus;
+  traceId: TraceId;
+  result?: unknown;
+  error?: AppError;
+}
+
+export interface LogRecord extends BaseEntity {
+  runId: string;
+  nodeId?: string;
+  timestamp: number;
+  level: LogLevel;
+  event: string;
+  data?: unknown;
+  traceId: TraceId;
 }
 
 export interface ImportExportSchema {


### PR DESCRIPTION
### 变更摘要
- 扩展运行时协议，新增 `ExecRequest`、`ExecEvent` 与 `NodeContext` 类型
- 统一错误结构 `{name,message,stack,code}` 并提供 `createError`/`serializeError`
- 将运行与日志记录接口移动至存储类型并补充序列化测试

### 细节
- 为执行请求与事件建立 Zod 验证模式
- 存储层新增 `RunRecord`、`LogRecord`，引用标准错误类型
- 编写单元测试覆盖类型校验及 JSON 序列化/反序列化

### 兼容性 / 风险
- 影响面：共享类型定义、运行时事件、错误处理
- 风险点：新类型若与现有调用不兼容可能导致编译失败
- 监控指标：构建与测试是否通过
- 回滚步骤：`git revert <commit>`

### 验证清单
- [ ] `npm run lint` / `format:check`
- [ ] `npm run type-check`
- [ ] `npm run test`（覆盖率达标）
- [ ] `npm run build`
- [ ] 手动场景：无


------
https://chatgpt.com/codex/tasks/task_b_68a95c892b5c832ab927b552bb328c71