### PR TITLE
feat(flow): 支持节点运行状态与错误展示

### DIFF
--- a/src/flow/RenderFlow.tsx
+++ b/src/flow/RenderFlow.tsx
@@ -9,6 +9,7 @@ import {
   Background,
   MiniMap,
   type BackgroundVariant,
+  type NodeProps,
 } from 'reactflow';
 import type { RenderFlowProps, FlowRenderOptions } from './renderFlow.types';
 import 'reactflow/dist/style.css';
@@ -31,6 +32,37 @@ const RenderFlow: React.FC<RenderFlowProps> = ({
 }) => {
   const config = { ...DEFAULT_OPTIONS, ...options };
 
+  const StatusNode: React.FC<NodeProps> = ({ data }) => {
+    const [showError, setShowError] = React.useState(false);
+    return (
+      <div className={`status-node status-${data.runtimeStatus || 'idle'}`}>
+        <div>{data.label}</div>
+        {data.runtimeStatus === 'error' && data.lastError && (
+          <div>
+            <button
+              type="button"
+              data-testid="error-toggle"
+              onClick={() => setShowError((v) => !v)}
+            >
+              !
+            </button>
+            {showError && (
+              <div data-testid="error-detail">
+                <span>{data.lastError}</span>
+                <button
+                  type="button"
+                  onClick={() => setShowError(false)}
+                >
+                  ×
+                </button>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    );
+  };
+
   return (
     <div
       className={`flow-container ${config.className}`}
@@ -42,6 +74,7 @@ const RenderFlow: React.FC<RenderFlowProps> = ({
         nodesDraggable={!config.readonly}
         nodesConnectable={!config.readonly}
         elementsSelectable={!config.readonly}
+        nodeTypes={{ default: StatusNode }}
         {...flowProps}
       >
         {config.showControls && (

--- a/src/flow/RenderFlow.tsx
+++ b/src/flow/RenderFlow.tsx
@@ -49,10 +49,7 @@ const RenderFlow: React.FC<RenderFlowProps> = ({
             {showError && (
               <div data-testid="error-detail">
                 <span>{data.lastError}</span>
-                <button
-                  type="button"
-                  onClick={() => setShowError(false)}
-                >
+                <button type="button" onClick={() => setShowError(false)}>
                   ×
                 </button>
               </div>

--- a/src/flow/__tests__/module.test.tsx
+++ b/src/flow/__tests__/module.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { FlowCanvas } from '../FlowCanvas';
@@ -18,16 +18,17 @@ vi.mock('reactflow', () => ({
   }) => (
     <div data-testid="react-flow">
       {nodes.map((n) => {
-        const Comp = nodeTypes[n.type || 'default'] ??
+        const Comp =
+          nodeTypes[n.type || 'default'] ??
           ((props: any) => <div>{props.data?.label}</div>);
         return <Comp key={n.id} id={n.id} data={n.data} />;
       })}
       {children}
     </div>
   ),
-  Controls: () => <div data-testid="flow-controls" />, 
-  Background: () => <div data-testid="flow-background" />, 
-  MiniMap: () => <div data-testid="flow-minimap" />, 
+  Controls: () => <div data-testid="flow-controls" />,
+  Background: () => <div data-testid="flow-background" />,
+  MiniMap: () => <div data-testid="flow-minimap" />,
 }));
 
 describe('Flow Module', () => {
@@ -98,10 +99,14 @@ describe('Flow Module', () => {
 
       render(<RenderFlow nodes={nodes} edges={[]} />);
       const toggle = screen.getByTestId('error-toggle');
-      await userEvent.click(toggle);
+      await act(async () => {
+        await userEvent.click(toggle);
+      });
       expect(screen.getByTestId('error-detail')).toHaveTextContent('failed');
       const closeBtn = screen.getByText('×');
-      await userEvent.click(closeBtn);
+      await act(async () => {
+        await userEvent.click(closeBtn);
+      });
       expect(screen.queryByTestId('error-detail')).toBeNull();
     });
   });

--- a/src/flow/__tests__/module.test.tsx
+++ b/src/flow/__tests__/module.test.tsx
@@ -1,18 +1,33 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { FlowCanvas } from '../FlowCanvas';
 import RenderFlow from '../RenderFlow';
 
 // Mock React Flow
 vi.mock('reactflow', () => ({
-  ReactFlow: ({ children }: { children: React.ReactNode }) =>
-    React.createElement('div', { 'data-testid': 'react-flow' }, children),
-  Controls: () =>
-    React.createElement('div', { 'data-testid': 'flow-controls' }),
-  Background: () =>
-    React.createElement('div', { 'data-testid': 'flow-background' }),
-  MiniMap: () => React.createElement('div', { 'data-testid': 'flow-minimap' }),
+  ReactFlow: ({
+    children,
+    nodes = [],
+    nodeTypes = {},
+  }: {
+    children: React.ReactNode;
+    nodes?: any[];
+    nodeTypes?: Record<string, React.FC<any>>;
+  }) => (
+    <div data-testid="react-flow">
+      {nodes.map((n) => {
+        const Comp = nodeTypes[n.type || 'default'] ??
+          ((props: any) => <div>{props.data?.label}</div>);
+        return <Comp key={n.id} id={n.id} data={n.data} />;
+      })}
+      {children}
+    </div>
+  ),
+  Controls: () => <div data-testid="flow-controls" />, 
+  Background: () => <div data-testid="flow-background" />, 
+  MiniMap: () => <div data-testid="flow-minimap" />, 
 }));
 
 describe('Flow Module', () => {
@@ -34,6 +49,18 @@ describe('Flow Module', () => {
       expect(typeof canvas.addEdge).toBe('function');
       expect(typeof canvas.deleteEdge).toBe('function');
     });
+
+    it('应该更新节点运行状态', () => {
+      const canvas = new FlowCanvas();
+      const node = canvas.addNode({ position: { x: 0, y: 0 }, name: 'n1' });
+      canvas.updateNodeRuntimeStatus(node.id, 'running');
+      let current = canvas.getNodes()[0]!;
+      expect(current.data.runtimeStatus).toBe('running');
+      canvas.updateNodeRuntimeStatus(node.id, 'error', 'boom');
+      current = canvas.getNodes()[0]!;
+      expect(current.data.runtimeStatus).toBe('error');
+      expect(current.data.lastError).toBe('boom');
+    });
   });
 
   describe('renderFlow', () => {
@@ -53,6 +80,29 @@ describe('Flow Module', () => {
     it('应该处理空节点数组', () => {
       render(<RenderFlow nodes={[]} edges={[]} />);
       expect(screen.getByTestId('react-flow')).toBeInTheDocument();
+    });
+
+    it('应该渲染错误信息并可关闭', async () => {
+      const nodes = [
+        {
+          id: '1',
+          type: 'default',
+          position: { x: 0, y: 0 },
+          data: {
+            label: 'Node 1',
+            runtimeStatus: 'error',
+            lastError: 'failed',
+          },
+        },
+      ];
+
+      render(<RenderFlow nodes={nodes} edges={[]} />);
+      const toggle = screen.getByTestId('error-toggle');
+      await userEvent.click(toggle);
+      expect(screen.getByTestId('error-detail')).toHaveTextContent('failed');
+      const closeBtn = screen.getByText('×');
+      await userEvent.click(closeBtn);
+      expect(screen.queryByTestId('error-detail')).toBeNull();
     });
   });
 });

--- a/src/shared/types/node.ts
+++ b/src/shared/types/node.ts
@@ -53,11 +53,15 @@ export interface NodePosition {
   y: number;
 }
 
+export type NodeRuntimeStatus = 'idle' | 'running' | 'success' | 'error';
+
 export interface FlowNode extends NodeMetadata {
   position: NodePosition;
   data?: Record<string, unknown>;
   selected?: boolean;
   dragging?: boolean;
+  runtimeStatus?: NodeRuntimeStatus;
+  lastError?: string;
 }
 
 export const EdgeTypeSchema = z.enum(['data', 'control']);


### PR DESCRIPTION
## Summary
- 扩展 FlowNode，增加运行状态与错误信息
- 依据 runtimeStatus 动态渲染节点样式
- 节点失败时可查看并关闭 lastError

## Testing
- `npm run type-check`
- `npm run lint`
- `npm run test -- --run`


------
https://chatgpt.com/codex/tasks/task_b_68abf39be5c0832a88c2aca70aafaee2