### PR TITLE
feat: 新增运行中心页面支持日志重试与过滤

### DIFF
--- a/src/run-center/RunCenterPage.tsx
+++ b/src/run-center/RunCenterPage.tsx
@@ -1,0 +1,118 @@
+import React, { useState, useMemo, useCallback } from 'react';
+
+export interface NodeLog {
+  id: string;
+  node: string;
+  status: 'success' | 'running' | 'failed';
+  message: string;
+  error?: string;
+}
+
+export interface RunCenterPageProps {
+  logs: NodeLog[];
+  onRetry?: (id: string) => void;
+}
+
+const PAGE_SIZE = 5;
+
+/**
+ * RunCenterPage 聚合流程画布、运行日志列表及全局进度条
+ */
+export const RunCenterPage: React.FC<RunCenterPageProps> = ({ logs, onRetry }) => {
+  const [search, setSearch] = useState('');
+  const [filter, setFilter] = useState<'all' | 'success' | 'running' | 'failed'>('all');
+  const [page, setPage] = useState(1);
+
+  const filteredLogs = useMemo(() => {
+    return logs
+      .filter((l) => (filter === 'all' ? true : l.status === filter))
+      .filter(
+        (l) =>
+          l.node.toLowerCase().includes(search.toLowerCase()) ||
+          l.message.toLowerCase().includes(search.toLowerCase()),
+      );
+  }, [logs, search, filter]);
+
+  const totalPages = Math.max(1, Math.ceil(filteredLogs.length / PAGE_SIZE));
+  const pageLogs = filteredLogs.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
+
+  const handleRetry = useCallback(
+    (id: string) => {
+      onRetry?.(id);
+    },
+    [onRetry],
+  );
+
+  return (
+    <div>
+      <div data-testid="flow-canvas" />
+      <div>
+        <progress
+          value={logs.filter((l) => l.status === 'success').length}
+          max={logs.length}
+          data-testid="global-progress"
+        />
+      </div>
+      <div>
+        <input
+          placeholder="搜索日志"
+          aria-label="search"
+          value={search}
+          onChange={(e) => {
+            setSearch(e.target.value);
+            setPage(1);
+          }}
+        />
+        <select
+          aria-label="filter"
+          value={filter}
+          onChange={(e) => {
+            setFilter(e.target.value as any);
+            setPage(1);
+          }}
+        >
+          <option value="all">全部</option>
+          <option value="success">成功</option>
+          <option value="running">运行中</option>
+          <option value="failed">失败</option>
+        </select>
+      </div>
+      <ul>
+        {pageLogs.map((log) => (
+          <li
+            key={log.id}
+            className={log.status === 'failed' ? 'failed' : ''}
+            data-testid="log-item"
+          >
+            <span>
+              {log.node}: {log.message}
+            </span>
+            {log.status === 'failed' && log.error && (
+              <pre data-testid="error-detail">{log.error}</pre>
+            )}
+            <button onClick={() => handleRetry(log.id)}>重新运行</button>
+          </li>
+        ))}
+      </ul>
+      <div>
+        <button
+          onClick={() => setPage((p) => Math.max(1, p - 1))}
+          disabled={page === 1}
+        >
+          上一页
+        </button>
+        <span>
+          {page}/{totalPages}
+        </span>
+        <button
+          onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+          disabled={page === totalPages}
+        >
+          下一页
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default RunCenterPage;

--- a/src/run-center/__tests__/RunCenterPage.test.tsx
+++ b/src/run-center/__tests__/RunCenterPage.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { RunCenterPage, NodeLog } from '../RunCenterPage';
+
+const logs: NodeLog[] = [
+  { id: '1', node: 'A', status: 'success', message: 'ok' },
+  { id: '2', node: 'B', status: 'failed', message: 'oops', error: 'detail' },
+  { id: '3', node: 'C', status: 'running', message: 'processing' },
+  { id: '4', node: 'D', status: 'success', message: 'done' },
+  { id: '5', node: 'E', status: 'success', message: 'done' },
+  { id: '6', node: 'F', status: 'success', message: 'done' },
+];
+
+describe('RunCenterPage', () => {
+  it('支持搜索和过滤日志', () => {
+    render(<RunCenterPage logs={logs} />);
+
+    const progress = screen.getByTestId('global-progress');
+    expect(progress).toHaveAttribute('value', '4');
+    expect(progress).toHaveAttribute('max', '6');
+
+    const search = screen.getByPlaceholderText('搜索日志');
+    fireEvent.change(search, { target: { value: 'B' } });
+    expect(screen.getAllByTestId('log-item')).toHaveLength(1);
+    expect(screen.getByText(/B/)).toBeInTheDocument();
+
+    fireEvent.change(search, { target: { value: '' } });
+    const filter = screen.getByLabelText('filter');
+    fireEvent.change(filter, { target: { value: 'failed' } });
+    expect(screen.getAllByTestId('log-item')).toHaveLength(1);
+    expect(screen.getByTestId('error-detail')).toHaveTextContent('detail');
+  });
+
+  it('支持分页和重新运行', () => {
+    const retry = vi.fn();
+    render(<RunCenterPage logs={logs} onRetry={retry} />);
+
+    expect(screen.getAllByTestId('log-item')).toHaveLength(5);
+    fireEvent.click(screen.getByText('下一页'));
+    expect(screen.getAllByTestId('log-item')).toHaveLength(1);
+
+    fireEvent.click(screen.getByText('重新运行'));
+    expect(retry).toHaveBeenCalledWith('6');
+  });
+});

--- a/src/run-center/index.ts
+++ b/src/run-center/index.ts
@@ -1,5 +1,7 @@
 export { RunCenter } from './RunCenter';
 export { RunCenterService } from './RunCenterService';
+export { RunCenterPage } from './RunCenterPage';
+export type { NodeLog } from './RunCenterPage';
 export type {
   RunRecord,
   RunLog,


### PR DESCRIPTION
## Summary
- 新增 `RunCenterPage` 聚合流程画布、日志列表及全局进度条
- 支持日志搜索、状态筛选、分页与单节点重新运行
- 为关键交互编写组件测试

## Testing
- `npm run type-check`
- `npm run lint`
- `npm run test -- --run`


------
https://chatgpt.com/codex/tasks/task_b_68abf39eede4832ab0107ac9d59c5c19