### PR TITLE
feat(planner): add DSL parser validation

### DIFF
--- a/src/planner/__tests__/dslParser.test.ts
+++ b/src/planner/__tests__/dslParser.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { parseBlueprintDSL, blueprintToDag } from '../';
+
+describe('parseBlueprintDSL', () => {
+  it('JSON 格式错误时返回明确错误', () => {
+    const result = parseBlueprintDSL('{ invalid');
+    expect(result.error).toMatch('JSON 格式错误');
+  });
+
+  it('语法错误时返回明确错误', () => {
+    const dsl = JSON.stringify({
+      nodes: [{ id: 'A' }, { id: 'B' }],
+      edges: [{ source: 'A', target: 'B!' }],
+    });
+    const result = parseBlueprintDSL(dsl);
+    expect(result.error).toMatch('语法错误');
+  });
+
+  it('检测并回退环结构', () => {
+    const dsl = JSON.stringify({
+      nodes: [{ id: 'A' }, { id: 'B' }],
+      edges: [
+        { id: 'e1', source: 'A', target: 'B' },
+        { id: 'e2', source: 'B', target: 'A' },
+      ],
+    });
+    const result = parseBlueprintDSL(dsl);
+    expect(result.warnings.some((w) => w.includes('环'))).toBe(true);
+    expect(result.blueprint?.edges.length).toBe(1);
+    const dag = blueprintToDag(result.blueprint!);
+    expect(dag.edges).toHaveLength(1);
+  });
+
+  it('分支结构生成警告但仍能转换', () => {
+    const dsl = JSON.stringify({
+      nodes: [{ id: 'A' }, { id: 'B' }, { id: 'C' }],
+      edges: [
+        { id: 'e1', source: 'A', target: 'B' },
+        { id: 'e2', source: 'A', target: 'C' },
+      ],
+    });
+    const result = parseBlueprintDSL(dsl);
+    expect(result.warnings.some((w) => w.includes('分支'))).toBe(true);
+    const dag = blueprintToDag(result.blueprint!);
+    expect(dag.edges).toHaveLength(2);
+  });
+});

--- a/src/planner/index.ts
+++ b/src/planner/index.ts
@@ -1,2 +1,3 @@
 export { blueprintToDag } from './blueprintToDag';
+export { parseBlueprintDSL } from './parseDsl';
 export type { PlannerConfig, ExecutionStrategy } from './types';

--- a/src/planner/parseDsl.ts
+++ b/src/planner/parseDsl.ts
@@ -1,0 +1,117 @@
+export interface ParseResult {
+  blueprint: { nodes: any[]; edges: any[] } | null;
+  warnings: string[];
+  error?: string;
+}
+
+const idPattern = /^[A-Za-z0-9_-]+$/;
+
+export function parseBlueprintDSL(dsl: string): ParseResult {
+  let raw: any;
+  try {
+    raw = JSON.parse(dsl);
+  } catch (e) {
+    return {
+      blueprint: null,
+      warnings: [],
+      error: `JSON 格式错误: ${(e as Error).message}`,
+    };
+  }
+
+  if (!raw || !Array.isArray(raw.nodes) || !Array.isArray(raw.edges)) {
+    return {
+      blueprint: null,
+      warnings: [],
+      error: 'DSL 必须包含 nodes 和 edges 数组',
+    };
+  }
+
+  const warnings: string[] = [];
+  const nodeIds = new Set<string>();
+  const nodes = raw.nodes.map((n: any) => {
+    const id = String(n.id);
+    if (!idPattern.test(id)) {
+      return null;
+    }
+    nodeIds.add(id);
+    return { id };
+  }) as ({ id: string } | null)[];
+  if (nodes.some((n) => n === null)) {
+    return { blueprint: null, warnings: [], error: '节点 ID 语法错误' };
+  }
+
+  const edges: { id: string; source: string; target: string }[] = [];
+  const adjacency = new Map<string, string[]>();
+  for (const e of raw.edges) {
+    if (
+      typeof e.source !== 'string' ||
+      typeof e.target !== 'string' ||
+      !idPattern.test(e.source) ||
+      !idPattern.test(e.target)
+    ) {
+      return {
+        blueprint: null,
+        warnings: [],
+        error: `边 ${e.id ?? ''} 语法错误`,
+      };
+    }
+    const id = e.id ? String(e.id) : `${e.source}-${e.target}`;
+    edges.push({ id, source: e.source, target: e.target });
+    const list = adjacency.get(e.source) ?? [];
+    list.push(e.target);
+    adjacency.set(e.source, list);
+  }
+
+  // 分支检测
+  for (const [source, targets] of adjacency) {
+    if (targets.length > 1) {
+      warnings.push(`节点 ${source} 存在分支`);
+    }
+  }
+
+  // 环检测与回退
+  const cycleEdges = new Set<string>();
+  const path = new Set<string>();
+  const visited = new Set<string>();
+
+  function dfs(node: string) {
+    path.add(node);
+    visited.add(node);
+    const targets = adjacency.get(node) || [];
+    for (const target of targets) {
+      if (path.has(target)) {
+        const edge = edges.find(
+          (ed) => ed.source === node && ed.target === target
+        );
+        if (edge) {
+          cycleEdges.add(edge.id);
+          warnings.push(`检测到环: ${node} -> ${target}`);
+        }
+        continue;
+      }
+      if (!visited.has(target)) {
+        dfs(target);
+      }
+    }
+    path.delete(node);
+  }
+
+  for (const id of nodeIds) {
+    if (!visited.has(id)) {
+      dfs(id);
+    }
+  }
+
+  let filteredEdges = edges;
+  if (cycleEdges.size > 0) {
+    warnings.push('已移除导致环的边');
+    filteredEdges = edges.filter((e) => !cycleEdges.has(e.id));
+  }
+
+  const blueprint: { nodes: any[]; edges: any[] } = {
+    nodes,
+    edges: filteredEdges,
+  };
+
+  return { blueprint, warnings };
+}


### PR DESCRIPTION
## Summary
- add `parseBlueprintDSL` with JSON/语法校验与环路、分支警告
- expose DSL parser via planner index
- cover invalid输入和复杂拓扑的单元测试

## Testing
- `npm run type-check`
- `npm run lint`
- `npm run format:check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68abf5e5b3b4832a95b8fea5b4e59b58