### PR TITLE
refactor: modularize flow editor components

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,20 +1,6 @@
 import React from 'react';
+import FlowEditor from '@/components/FlowEditor';
 
-const App: React.FC = () => {
-  return (
-    <div className="app">
-      <header className="app-header">
-        <h1>Superflow</h1>
-        <p>想法到流程的开放平台</p>
-      </header>
-      <main className="app-main">
-        <div className="welcome-message">
-          <h2>欢迎使用 Superflow</h2>
-          <p>项目骨架已创建完成，准备开始开发！</p>
-        </div>
-      </main>
-    </div>
-  );
-};
+const App: React.FC = () => <FlowEditor />;
 
 export default App;

--- a/src/components/EditorPanel.tsx
+++ b/src/components/EditorPanel.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+export interface EditorPanelProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+const EditorPanel: React.FC<EditorPanelProps> = ({ value, onChange }) => (
+  <div className="editor-panel">
+    <label htmlFor="editor-input">输入</label>
+    <input
+      id="editor-input"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+    />
+  </div>
+);
+
+export default EditorPanel;

--- a/src/components/FlowEditor.tsx
+++ b/src/components/FlowEditor.tsx
@@ -1,0 +1,78 @@
+import React, { useState } from 'react';
+import ReactFlow, {
+  Background,
+  Controls,
+  type Node,
+  type Edge,
+} from 'reactflow';
+import { InputNode, TransformNode, OutputNode } from './nodes';
+import EditorPanel from './EditorPanel';
+import PreviewRunner from './PreviewRunner';
+
+const nodeTypes = {
+  input: InputNode,
+  transform: TransformNode,
+  output: OutputNode,
+};
+
+const initialNodes: Node[] = [
+  {
+    id: 'input',
+    type: 'input',
+    position: { x: 0, y: 0 },
+    data: { label: '输入', value: 'hello' },
+  },
+  {
+    id: 'transform',
+    type: 'transform',
+    position: { x: 200, y: 0 },
+    data: { label: '转换', operation: 'uppercase' },
+  },
+  {
+    id: 'output',
+    type: 'output',
+    position: { x: 400, y: 0 },
+    data: { label: '输出' },
+  },
+];
+
+const initialEdges: Edge[] = [
+  { id: 'e1-2', source: 'input', target: 'transform' },
+  { id: 'e2-3', source: 'transform', target: 'output' },
+];
+
+const FlowEditor: React.FC = () => {
+  const [nodes, setNodes] = useState<Node[]>(initialNodes);
+  const [edges] = useState<Edge[]>(initialEdges);
+  const [inputValue, setInputValue] = useState('hello');
+  const [previewResult, setPreviewResult] = useState<unknown>();
+
+  const handleInputChange = (value: string): void => {
+    setInputValue(value);
+    setNodes((nds) =>
+      nds.map((n) =>
+        n.id === 'input' ? { ...n, data: { ...n.data, value } } : n
+      )
+    );
+  };
+
+  return (
+    <div style={{ display: 'flex', height: '100%' }}>
+      <div style={{ flex: 1 }}>
+        <ReactFlow nodes={nodes} edges={edges} nodeTypes={nodeTypes}>
+          <Background />
+          <Controls />
+        </ReactFlow>
+      </div>
+      <div style={{ width: 240, padding: 8 }}>
+        <EditorPanel value={inputValue} onChange={handleInputChange} />
+        <PreviewRunner nodes={nodes} onResult={setPreviewResult} />
+        {previewResult !== undefined && (
+          <div className="preview-display">结果: {String(previewResult)}</div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default FlowEditor;

--- a/src/components/PreviewRunner.tsx
+++ b/src/components/PreviewRunner.tsx
@@ -1,0 +1,39 @@
+import React, { useState } from 'react';
+import type { Node } from 'reactflow';
+import { safeCopy } from '@/utils/safeCopy';
+
+interface RunnerProps {
+  nodes: Node[];
+  onResult?: (result: unknown) => void;
+}
+
+const PreviewRunner: React.FC<RunnerProps> = ({ nodes, onResult }) => {
+  const [result, setResult] = useState<unknown>();
+
+  const run = (): void => {
+    const copy = safeCopy(nodes);
+    let current = copy.find((n) => n.type === 'input')?.data?.value;
+    copy
+      .filter((n) => n.type === 'transform')
+      .forEach((n) => {
+        if (n.data && (n.data as any).operation === 'uppercase') {
+          current = String(current).toUpperCase();
+        }
+      });
+    setResult(current);
+    onResult?.(current);
+  };
+
+  return (
+    <div className="preview-runner">
+      <button onClick={run}>预览</button>
+      {result !== undefined && (
+        <div role="result" className="preview-result">
+          {String(result)}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default PreviewRunner;

--- a/src/components/__tests__/EditorPanel.test.tsx
+++ b/src/components/__tests__/EditorPanel.test.tsx
@@ -1,0 +1,14 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import EditorPanel from '@/components/EditorPanel';
+
+describe('EditorPanel', () => {
+  it('触发 onChange', () => {
+    const handler = vi.fn();
+    render(<EditorPanel value="" onChange={handler} />);
+    fireEvent.change(screen.getByLabelText('输入'), {
+      target: { value: 'test' },
+    });
+    expect(handler).toHaveBeenCalledWith('test');
+  });
+});

--- a/src/components/__tests__/PreviewRunner.test.tsx
+++ b/src/components/__tests__/PreviewRunner.test.tsx
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import PreviewRunner from '@/components/PreviewRunner';
+import type { Node } from 'reactflow';
+
+describe('PreviewRunner', () => {
+  it('执行预览并返回结果', () => {
+    const nodes: Node[] = [
+      {
+        id: 'a',
+        type: 'input',
+        position: { x: 0, y: 0 },
+        data: { value: 'abc' },
+      },
+      {
+        id: 'b',
+        type: 'transform',
+        position: { x: 0, y: 0 },
+        data: { operation: 'uppercase' },
+      },
+      { id: 'c', type: 'output', position: { x: 0, y: 0 }, data: {} },
+    ];
+
+    const handler = vi.fn();
+    render(<PreviewRunner nodes={nodes} onResult={handler} />);
+    fireEvent.click(screen.getByText('预览'));
+    expect(handler).toHaveBeenCalledWith('ABC');
+    expect(screen.getByRole('result').textContent).toBe('ABC');
+  });
+});

--- a/src/components/nodes/InputNode.tsx
+++ b/src/components/nodes/InputNode.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import type { NodeProps } from 'reactflow';
+
+export interface InputNodeData {
+  label: string;
+  value?: string;
+}
+
+const InputNode: React.FC<NodeProps<InputNodeData>> = ({ data }) => (
+  <div className="input-node">
+    <strong>{data.label}</strong>
+    {data.value !== undefined && <div>{data.value}</div>}
+  </div>
+);
+
+export default InputNode;

--- a/src/components/nodes/OutputNode.tsx
+++ b/src/components/nodes/OutputNode.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import type { NodeProps } from 'reactflow';
+
+export interface OutputNodeData {
+  label: string;
+}
+
+const OutputNode: React.FC<NodeProps<OutputNodeData>> = ({ data }) => (
+  <div className="output-node">
+    <strong>{data.label}</strong>
+  </div>
+);
+
+export default OutputNode;

--- a/src/components/nodes/TransformNode.tsx
+++ b/src/components/nodes/TransformNode.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import type { NodeProps } from 'reactflow';
+
+export interface TransformNodeData {
+  label: string;
+  operation?: 'uppercase';
+}
+
+const TransformNode: React.FC<NodeProps<TransformNodeData>> = ({ data }) => (
+  <div className="transform-node">
+    <strong>{data.label}</strong>
+    {data.operation && <div>操作: {data.operation}</div>}
+  </div>
+);
+
+export default TransformNode;

--- a/src/components/nodes/__tests__/nodes.test.tsx
+++ b/src/components/nodes/__tests__/nodes.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { InputNode, TransformNode, OutputNode } from '@/components/nodes';
+import type { TransformNodeData } from '@/components/nodes';
+import type { NodeProps } from 'reactflow';
+
+describe('自定义节点', () => {
+  const createProps = <T,>(data: T): NodeProps<T> => ({
+    id: '1',
+    type: 'custom',
+    data,
+    selected: false,
+    isConnectable: false,
+    xPos: 0,
+    yPos: 0,
+    zIndex: 0,
+    dragging: false,
+  });
+
+  it('渲染 InputNode', () => {
+    const props = createProps<{ label: string; value: string }>({
+      label: '输入',
+      value: 'a',
+    });
+    render(<InputNode {...props} />);
+    expect(screen.getByText('输入')).toBeInTheDocument();
+    expect(screen.getByText('a')).toBeInTheDocument();
+  });
+
+  it('渲染 TransformNode', () => {
+    const props = createProps<TransformNodeData>({
+      label: '转换',
+      operation: 'uppercase',
+    });
+    render(<TransformNode {...props} />);
+    expect(screen.getByText('转换')).toBeInTheDocument();
+    expect(screen.getByText('操作: uppercase')).toBeInTheDocument();
+  });
+
+  it('渲染 OutputNode', () => {
+    const props = createProps({ label: '输出' });
+    render(<OutputNode {...props} />);
+    expect(screen.getByText('输出')).toBeInTheDocument();
+  });
+});

--- a/src/components/nodes/index.ts
+++ b/src/components/nodes/index.ts
@@ -1,0 +1,6 @@
+export { default as InputNode } from './InputNode';
+export { default as TransformNode } from './TransformNode';
+export { default as OutputNode } from './OutputNode';
+export type { InputNodeData } from './InputNode';
+export type { TransformNodeData } from './TransformNode';
+export type { OutputNodeData } from './OutputNode';

--- a/src/utils/__tests__/safeCopy.test.ts
+++ b/src/utils/__tests__/safeCopy.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import { safeCopy } from '@/utils/safeCopy';
+
+describe('safeCopy', () => {
+  it('深拷贝对象', () => {
+    const original = { nested: { value: 1 } };
+    const copy = safeCopy(original);
+    (copy.nested as { value: number }).value = 2;
+    expect(original.nested.value).toBe(1);
+  });
+});

--- a/src/utils/safeCopy.ts
+++ b/src/utils/safeCopy.ts
@@ -1,0 +1,6 @@
+export function safeCopy<T>(value: T): T {
+  if (typeof structuredClone === 'function') {
+    return structuredClone(value);
+  }
+  return JSON.parse(JSON.stringify(value)) as T;
+}


### PR DESCRIPTION
## Summary
- move Input/Transform/Output nodes to components/nodes
- split editor panel, preview runner and safe copy into modules
- add unit tests for new modules

## Testing
- `npm run type-check`
- `npm run lint` (warnings)
- `npm run format:check`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_b_68abf5e7b43c832aab49cbf99538f113