### PR TITLE
feat(utils): add clipboard fallback and user prompts

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,8 @@ const App: React.FC = () => {
         <div className="welcome-message">
           <h2>欢迎使用 Superflow</h2>
           <p>项目骨架已创建完成，准备开始开发！</p>
+        </div>
+        <div>
           <input ref={inputRef} placeholder="输入要复制的文本" />
           <button onClick={handleCopy}>复制</button>
           {copyStatus && <p>{copyStatus}</p>}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,16 @@
-import React from 'react';
+import React, { useRef, useState } from 'react';
+import { copyText } from '@/utils';
 
 const App: React.FC = () => {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [copyStatus, setCopyStatus] = useState('');
+
+  const handleCopy = async () => {
+    const text = inputRef.current?.value ?? '';
+    const result = await copyText(text, inputRef.current);
+    setCopyStatus(result.success ? '已复制' : result.message || '请手动复制');
+  };
+
   return (
     <div className="app">
       <header className="app-header">
@@ -11,6 +21,9 @@ const App: React.FC = () => {
         <div className="welcome-message">
           <h2>欢迎使用 Superflow</h2>
           <p>项目骨架已创建完成，准备开始开发！</p>
+          <input ref={inputRef} placeholder="输入要复制的文本" />
+          <button onClick={handleCopy}>复制</button>
+          {copyStatus && <p>{copyStatus}</p>}
         </div>
       </main>
     </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
-import React, { useRef, useState } from 'react';
+import React from 'react';
+import { useRef, useState } from 'react';
 import { copyText } from '@/utils';
 
 const App: React.FC = () => {

--- a/src/utils/clipboard.test.ts
+++ b/src/utils/clipboard.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { copyText } from './clipboard';
+
+describe('copyText', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    // @ts-expect-error - restore clipboard
+    delete navigator.clipboard;
+    // @ts-expect-error - restore execCommand
+    delete document.execCommand;
+  });
+
+  it('uses navigator.clipboard when available', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+
+    const result = await copyText('hello');
+
+    expect(writeText).toHaveBeenCalledWith('hello');
+    expect(result.success).toBe(true);
+  });
+
+  it('falls back to hidden input when native API fails', async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error('fail'));
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+
+    const execCommand = vi.fn().mockImplementation(() => {
+      const temp = document.body.querySelector('input');
+      expect(temp).not.toBeNull();
+      return true;
+    });
+    Object.defineProperty(document, 'execCommand', {
+      configurable: true,
+      value: execCommand,
+    });
+
+    const result = await copyText('text');
+
+    expect(execCommand).toHaveBeenCalledWith('copy');
+    expect(document.body.querySelector('input')).toBeNull();
+    expect(result.success).toBe(true);
+  });
+
+  it('returns error when execCommand fails', async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error('fail'));
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+
+    Object.defineProperty(document, 'execCommand', {
+      configurable: true,
+      value: vi.fn().mockReturnValue(false),
+    });
+
+    const result = await copyText('text');
+
+    expect(result.success).toBe(false);
+    expect(result.message).toMatch(/手动复制/);
+  });
+});

--- a/src/utils/clipboard.ts
+++ b/src/utils/clipboard.ts
@@ -1,0 +1,74 @@
+/**
+ * 复制文本到剪贴板，包含多种降级处理
+ */
+
+export interface CopyResult {
+  /** 是否复制成功 */
+  success: boolean;
+  /** 失败时的错误提示 */
+  message?: string;
+}
+
+/**
+ * 尝试将文本复制到剪贴板
+ * @param text 要复制的文本
+ * @param inputRef 可选的输入框引用，若提供则使用其执行复制
+ */
+export async function copyText(
+  text: string,
+  inputRef?: HTMLInputElement | null
+): Promise<CopyResult> {
+  // 优先使用原生异步 Clipboard API
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return { success: true };
+    } catch {
+      // 忽略错误，转而使用 document.execCommand
+    }
+  }
+
+  let input = inputRef ?? undefined;
+  let cleanup = false;
+
+  // 未传入 inputRef 时创建隐藏输入框
+  if (!input) {
+    input = document.createElement('input');
+    input.value = text;
+    input.setAttribute('aria-hidden', 'true');
+    input.style.position = 'fixed';
+    input.style.opacity = '0';
+    input.style.pointerEvents = 'none';
+    document.body.appendChild(input);
+    cleanup = true;
+  } else {
+    input.value = text;
+  }
+
+  input.select();
+
+  try {
+    const ok = document.execCommand('copy');
+    if (cleanup) {
+      document.body.removeChild(input);
+    }
+    if (ok) {
+      return { success: true };
+    }
+    return {
+      success: false,
+      message: '浏览器不支持自动复制，请手动复制',
+    };
+  } catch (err) {
+    if (cleanup) {
+      document.body.removeChild(input);
+    }
+    return {
+      success: false,
+      message:
+        err instanceof Error
+          ? `复制失败: ${err.message}`
+          : '复制失败，请手动复制',
+    };
+  }
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -11,6 +11,9 @@ export * from './uuid';
 // 日志工具
 export * from './logger';
 
+// 剪贴板工具
+export * from './clipboard';
+
 // 重新导出常用函数（兼容性）
 export { generateULID as generateId, isValidULID as isValidId } from './uuid';
 


### PR DESCRIPTION
## Summary
- add copyText utility with hidden input fallback and clearer errors
- show copy status in App based on copyText result
- cover copyText with unit tests

## Testing
- `npm run type-check`
- `npm run lint`
- `npm run format:check`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_b_68abf5e67d34832a97e40d2c810cdfbf