### PR TITLE
feat(utils): sandbox preview runner

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -10,6 +10,8 @@ export * from './uuid';
 
 // 日志工具
 export * from './logger';
+// 预览运行器
+export * from './preview-runner';
 
 // 重新导出常用函数（兼容性）
 export { generateULID as generateId, isValidULID as isValidId } from './uuid';

--- a/src/utils/preview-runner.ts
+++ b/src/utils/preview-runner.ts
@@ -1,0 +1,56 @@
+export interface PreviewRunnerMessage {
+  id: number;
+  fn: string;
+  arg: unknown;
+}
+
+export interface PreviewRunnerResponse {
+  id: number;
+  result?: unknown;
+  error?: string;
+}
+
+export class PreviewRunner {
+  private worker: Worker;
+  private seq = 0;
+  private pending = new Map<
+    number,
+    { resolve: (v: unknown) => void; reject: (err: Error) => void }
+  >();
+
+  constructor() {
+    this.worker = new Worker(
+      new URL('./preview-runner.worker.ts', import.meta.url),
+      { type: 'module' }
+    );
+    this.worker.onmessage = (event: MessageEvent<PreviewRunnerResponse>) => {
+      const { id, result, error } = event.data;
+      const pending = this.pending.get(id);
+      if (!pending) return;
+      this.pending.delete(id);
+      if (error) {
+        pending.reject(new Error(error));
+      } else {
+        pending.resolve(result);
+      }
+    };
+  }
+
+  run<T, R>(fn: (arg: T) => R | Promise<R>, arg: T): Promise<R> {
+    const id = this.seq++;
+    return new Promise<R>((resolve, reject) => {
+      // 存储回调时统一使用 unknown 类型
+      this.pending.set(id, {
+        resolve: resolve as (v: unknown) => void,
+        reject,
+      });
+      const message: PreviewRunnerMessage = { id, fn: fn.toString(), arg };
+      this.worker.postMessage(message);
+    });
+  }
+
+  terminate(): void {
+    this.worker.terminate();
+    this.pending.clear();
+  }
+}

--- a/src/utils/preview-runner.worker.ts
+++ b/src/utils/preview-runner.worker.ts
@@ -1,0 +1,20 @@
+self.onmessage = async (event: MessageEvent) => {
+  const { id, fn, arg } = event.data as {
+    id: number;
+    fn: string;
+    arg: unknown;
+  };
+  try {
+    // 使用 Function 构造函数执行传入的函数，避免主线程直接 eval
+    const handler = new Function(`return (${fn})`)();
+    const result = await handler(arg);
+    self.postMessage({ id, result });
+  } catch (err) {
+    self.postMessage({
+      id,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+};
+
+export {};


### PR DESCRIPTION
## Summary
- use Web Worker to run preview functions in isolation and relay results via postMessage
- export new PreviewRunner through utils index

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`
- `npm run format:check`


------
https://chatgpt.com/codex/tasks/task_b_68abf5baeda4832aa75a3d315d0558a8