### PR TITLE
test: 为 math 工具函数添加单元测试

### DIFF
--- a/src/utils/__tests__/math.test.ts
+++ b/src/utils/__tests__/math.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { clamp, lerp, distance } from '@/utils/math';
+
+describe('math 工具函数', () => {
+  describe('clamp', () => {
+    it('在范围内返回原值', () => {
+      expect(clamp(5, 0, 10)).toBe(5);
+    });
+
+    it('小于最小值时返回最小值', () => {
+      expect(clamp(-1, 0, 10)).toBe(0);
+    });
+
+    it('大于最大值时返回最大值', () => {
+      expect(clamp(11, 0, 10)).toBe(10);
+    });
+  });
+
+  describe('lerp', () => {
+    it('t=0 返回起始值', () => {
+      expect(lerp(0, 10, 0)).toBe(0);
+    });
+
+    it('t=1 返回结束值', () => {
+      expect(lerp(0, 10, 1)).toBe(10);
+    });
+
+    it('t=0.5 返回中间值', () => {
+      expect(lerp(0, 10, 0.5)).toBe(5);
+    });
+  });
+
+  describe('distance', () => {
+    it('计算两点间距离', () => {
+      expect(distance(0, 0, 3, 4)).toBe(5);
+    });
+
+    it('相同点距离为 0', () => {
+      expect(distance(1, 1, 1, 1)).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## 概述
- 为 `clamp`、`lerp`、`distance` 增加单元测试，覆盖常规与边界输入

## 测试
- `npx vitest run`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68b9295c0880832a9fd09fd1d0e4040b