### PR TITLE
feat: 兼容无 DOM 环境的复制逻辑

### DIFF
--- a/src/utils/clipboard.test.ts
+++ b/src/utils/clipboard.test.ts
@@ -4,6 +4,7 @@ import { copyText } from './clipboard';
 describe('copyText', () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
     // @ts-expect-error - restore clipboard
     delete navigator.clipboard;
     // @ts-expect-error - restore execCommand
@@ -63,5 +64,23 @@ describe('copyText', () => {
 
     expect(result.success).toBe(false);
     expect(result.message).toMatch(/手动复制/);
+  });
+
+  it('returns error when navigator is undefined', async () => {
+    vi.stubGlobal('navigator', undefined as any);
+
+    const result = await copyText('text');
+
+    expect(result.success).toBe(false);
+    expect(result.message).toMatch(/环境不支持/);
+  });
+
+  it('returns error when document is undefined', async () => {
+    vi.stubGlobal('document', undefined as any);
+
+    const result = await copyText('text');
+
+    expect(result.success).toBe(false);
+    expect(result.message).toMatch(/环境不支持/);
   });
 });

--- a/src/utils/clipboard.ts
+++ b/src/utils/clipboard.ts
@@ -18,6 +18,9 @@ export async function copyText(
   text: string,
   inputRef?: HTMLInputElement | null
 ): Promise<CopyResult> {
+  if (typeof navigator === 'undefined' || typeof document === 'undefined') {
+    return { success: false, message: '当前环境不支持复制' };
+  }
   // 优先使用原生异步 Clipboard API
   if (navigator.clipboard && navigator.clipboard.writeText) {
     try {


### PR DESCRIPTION
## Summary
- 在 `copyText` 中检查 `navigator` 与 `document` 是否存在，缺失时返回失败提示
- 补充单测覆盖无 DOM 环境下的行为

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68b9295dae30832ab8d2ad317d76aa63