### PR TITLE
test: add FlowEditor integration

### DIFF
--- a/src/components/__tests__/FlowEditor.test.tsx
+++ b/src/components/__tests__/FlowEditor.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import FlowEditor from '@/components/FlowEditor';
+
+vi.mock('reactflow', () => {
+  const ReactFlow = ({
+    children,
+    nodes = [],
+    nodeTypes = {},
+  }: {
+    children: React.ReactNode;
+    nodes?: Array<{ id: string; type?: string; data?: unknown }>;
+    nodeTypes?: Record<string, React.FC<{ id: string; data?: unknown }>>;
+  }) => (
+    <div data-testid="react-flow">
+      {nodes.map((n) => {
+        const Comp = nodeTypes[n.type || ''] as
+          | React.FC<{ id: string; data?: unknown }>
+          | undefined;
+        return Comp ? <Comp key={n.id} id={n.id} data={n.data} /> : null;
+      })}
+      {children}
+    </div>
+  );
+  return {
+    __esModule: true,
+    default: ReactFlow,
+    ReactFlow,
+    Controls: () => <div />,
+    Background: () => <div />,
+  };
+});
+
+describe('FlowEditor', () => {
+  it('更新输入节点并显示预览结果', () => {
+    render(<FlowEditor />);
+
+    expect(screen.getByText('hello')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('输入'), { target: { value: 'world' } });
+
+    expect(screen.getByText('world')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('预览'));
+
+    expect(screen.getByText('结果: WORLD')).toBeInTheDocument();
+  });
+});
+

--- a/src/components/__tests__/FlowEditor.test.tsx
+++ b/src/components/__tests__/FlowEditor.test.tsx
@@ -38,7 +38,9 @@ describe('FlowEditor', () => {
 
     expect(screen.getByText('hello')).toBeInTheDocument();
 
-    fireEvent.change(screen.getByLabelText('输入'), { target: { value: 'world' } });
+    fireEvent.change(screen.getByLabelText('输入'), {
+      target: { value: 'world' },
+    });
 
     expect(screen.getByText('world')).toBeInTheDocument();
 
@@ -47,4 +49,3 @@ describe('FlowEditor', () => {
     expect(screen.getByText('结果: WORLD')).toBeInTheDocument();
   });
 });
-


### PR DESCRIPTION
## Summary
- add FlowEditor component test
- cover input editing and preview running

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b9295b6680832abc6d9ba4c0c3e702