### PR TITLE
refactor: 抽离 FlowCanvas 执行逻辑并补充测试

### DIFF
--- a/src/flow/FlowCanvas.ts
+++ b/src/flow/FlowCanvas.ts
@@ -27,6 +27,13 @@ const STATUS_STYLES: Record<NodeRuntimeStatus, React.CSSProperties> = {
   error: { border: '2px solid #ef4444' },
 };
 import type { ExecutionDAG } from '@/planner/types';
+import {
+  processErrorNodes,
+  processInputNodes,
+  processTransformNodes,
+  processConditionalBranches,
+  processOutputNodes,
+} from './executor';
 
 /**
  * 流程画布配置
@@ -724,106 +731,11 @@ export class FlowCanvas {
 
       // 执行节点逻辑
       const outputs: Record<string, unknown> = {};
-      let currentData = input;
-
-      // 检查是否有错误节点（用于测试错误场景）
-      const errorNodes = this.nodes.filter(
-        (node) => node.type === 'error' || node.data?.shouldFail
-      );
-      for (const errorNode of errorNodes) {
-        if (
-          errorNode.data?.handler &&
-          typeof errorNode.data.handler === 'function'
-        ) {
-          // 执行错误节点的 handler，这会抛出错误
-          await errorNode.data.handler();
-        } else {
-          throw new Error('节点执行失败');
-        }
-      }
-
-      // 按拓扑顺序执行节点
-      const inputNodes = this.nodes.filter((node) => node.type === 'input');
-      const transformNodes = this.nodes.filter(
-        (node) => node.type === 'transform'
-      );
-      const outputNodes = this.nodes.filter((node) => node.type === 'output');
-
-      // 1. 处理输入节点
-      for (const inputNode of inputNodes) {
-        if (inputNode.data?.value) {
-          currentData = inputNode.data.value;
-        }
-      }
-
-      // 2. 处理转换节点
-      for (const transformNode of transformNodes) {
-        if (
-          transformNode.data?.handler &&
-          typeof transformNode.data.handler === 'function'
-        ) {
-          currentData = await transformNode.data.handler(currentData);
-        } else if (
-          transformNode.data?.operation === 'uppercase' &&
-          typeof currentData === 'string'
-        ) {
-          currentData = currentData.toUpperCase();
-        }
-      }
-
-      // 3. 处理条件分支
-      const conditionNodes = this.nodes.filter(
-        (node) => node.type === 'condition'
-      );
-      const processNodes = this.nodes.filter((node) => node.type === 'process');
-
-      for (const conditionNode of conditionNodes) {
-        if (
-          conditionNode.data?.condition &&
-          typeof input === 'object' &&
-          input !== null
-        ) {
-          const inputValue = (input as Record<string, unknown>).input;
-          if (
-            typeof inputValue === 'number' &&
-            typeof conditionNode.data.condition === 'function'
-          ) {
-            const conditionResult = conditionNode.data.condition(inputValue);
-
-            // 根据条件结果执行对应的分支
-            if (conditionResult) {
-              // 找到 true 分支节点
-              const trueBranchNode = processNodes.find(
-                (node) => node.id === 'true-branch'
-              );
-              if (trueBranchNode && trueBranchNode.data?.value) {
-                outputs['true-branch'] = trueBranchNode.data.value;
-              }
-            } else {
-              // 找到 false 分支节点
-              const falseBranchNode = processNodes.find(
-                (node) => node.id === 'false-branch'
-              );
-              if (falseBranchNode && falseBranchNode.data?.value) {
-                outputs['false-branch'] = falseBranchNode.data.value;
-              }
-            }
-          }
-        }
-      }
-
-      // 4. 处理输出节点（仅当没有条件分支的情况下）
-      if (outputNodes.length > 0 && Object.keys(outputs).length === 0) {
-        outputNodes.forEach((outputNode) => {
-          if (outputNode.data?.label) {
-            outputs[outputNode.data.label] = currentData;
-          } else {
-            outputs.output = currentData;
-          }
-        });
-      } else if (Object.keys(outputs).length === 0) {
-        outputs.output = currentData;
-      }
+      await processErrorNodes(this.nodes);
+      let currentData = processInputNodes(this.nodes, input);
+      currentData = await processTransformNodes(this.nodes, currentData);
+      processConditionalBranches(this.nodes, input, outputs);
+      processOutputNodes(this.nodes, currentData, outputs);
 
       // 如果有 RunCenter，记录完成日志
       if (runCenter && runId) {

--- a/src/flow/__tests__/execute.test.ts
+++ b/src/flow/__tests__/execute.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi } from 'vitest';
+import { FlowCanvas } from '../FlowCanvas';
+
+// 单元测试：验证执行逻辑
+
+describe('流程执行', () => {
+  it('应按顺序执行节点并返回输出', async () => {
+    const canvas = new FlowCanvas();
+    canvas.addNode({
+      id: 'in',
+      kind: 'input',
+      position: { x: 0, y: 0 },
+      data: { value: 'hello' },
+    });
+    canvas.addNode({
+      id: 'trans',
+      kind: 'transform',
+      position: { x: 0, y: 0 },
+      data: { handler: (d: string) => `${d} world` },
+    });
+    canvas.addNode({
+      id: 'out',
+      kind: 'output',
+      position: { x: 0, y: 0 },
+      data: { label: 'result' },
+    });
+
+    const result = await canvas.execute();
+    expect(result.status).toBe('completed');
+    expect(result.outputs?.result).toBe('hello world');
+  });
+
+  it('应在错误节点时返回失败', async () => {
+    const canvas = new FlowCanvas();
+    canvas.addNode({
+      id: 'err',
+      kind: 'custom',
+      position: { x: 0, y: 0 },
+      data: {
+        handler: () => {
+          throw new Error('boom');
+        },
+        shouldFail: true,
+      },
+    });
+
+    const result = await canvas.execute();
+    expect(result.status).toBe('failed');
+    expect(result.error).toContain('boom');
+  });
+
+  it('应与 RunCenter 集成记录状态', async () => {
+    const canvas = new FlowCanvas();
+    canvas.addNode({
+      id: 'in',
+      kind: 'input',
+      position: { x: 0, y: 0 },
+      data: { value: 1 },
+    });
+
+    const runCenter = {
+      addLog: vi.fn(async () => {}),
+      updateRunStatus: vi.fn(async () => {}),
+    };
+
+    const res = await canvas.execute('run1', undefined, runCenter);
+    expect(res.status).toBe('completed');
+    expect(runCenter.addLog).toHaveBeenCalled();
+    expect(runCenter.updateRunStatus).toHaveBeenCalledWith(
+      'run1',
+      'completed',
+      expect.any(Object)
+    );
+  });
+});

--- a/src/flow/executor.ts
+++ b/src/flow/executor.ts
@@ -1,0 +1,116 @@
+import type { Node } from 'reactflow';
+
+/**
+ * 处理可能抛出错误的节点
+ */
+export async function processErrorNodes(nodes: Node[]): Promise<void> {
+  const errorNodes = nodes.filter(
+    (node) => node.type === 'error' || (node.data as any)?.shouldFail
+  );
+  for (const errorNode of errorNodes) {
+    const handler = (errorNode.data as any)?.handler;
+    if (handler && typeof handler === 'function') {
+      await handler();
+    } else {
+      throw new Error('节点执行失败');
+    }
+  }
+}
+
+/**
+ * 处理输入节点
+ */
+export function processInputNodes(nodes: Node[], input?: unknown): unknown {
+  let current = input;
+  const inputNodes = nodes.filter((node) => node.type === 'input');
+  for (const inputNode of inputNodes) {
+    const value = (inputNode.data as any)?.value;
+    if (value !== undefined) {
+      current = value;
+    }
+  }
+  return current;
+}
+
+/**
+ * 处理转换节点
+ */
+export async function processTransformNodes(
+  nodes: Node[],
+  data: unknown
+): Promise<unknown> {
+  let current = data;
+  const transformNodes = nodes.filter((node) => node.type === 'transform');
+  for (const transformNode of transformNodes) {
+    const nodeData = transformNode.data as any;
+    if (nodeData?.handler && typeof nodeData.handler === 'function') {
+      current = await nodeData.handler(current);
+    } else if (
+      nodeData?.operation === 'uppercase' &&
+      typeof current === 'string'
+    ) {
+      current = current.toUpperCase();
+    }
+  }
+  return current;
+}
+
+/**
+ * 处理条件节点
+ */
+export function processConditionalBranches(
+  nodes: Node[],
+  input: unknown,
+  outputs: Record<string, unknown>
+): void {
+  const conditionNodes = nodes.filter((node) => node.type === 'condition');
+  const processNodes = nodes.filter((node) => node.type === 'process');
+  for (const conditionNode of conditionNodes) {
+    const nodeData = conditionNode.data as any;
+    if (nodeData?.condition && typeof input === 'object' && input !== null) {
+      const inputValue = (input as Record<string, unknown>).input;
+      if (
+        typeof inputValue === 'number' &&
+        typeof nodeData.condition === 'function'
+      ) {
+        const result = nodeData.condition(inputValue);
+        if (result) {
+          const trueNode = processNodes.find((n) => n.id === 'true-branch');
+          const value = (trueNode?.data as any)?.value;
+          if (value !== undefined) {
+            outputs['true-branch'] = value;
+          }
+        } else {
+          const falseNode = processNodes.find((n) => n.id === 'false-branch');
+          const value = (falseNode?.data as any)?.value;
+          if (value !== undefined) {
+            outputs['false-branch'] = value;
+          }
+        }
+      }
+    }
+  }
+}
+
+/**
+ * 处理输出节点
+ */
+export function processOutputNodes(
+  nodes: Node[],
+  data: unknown,
+  outputs: Record<string, unknown>
+): void {
+  const outputNodes = nodes.filter((node) => node.type === 'output');
+  if (outputNodes.length > 0 && Object.keys(outputs).length === 0) {
+    outputNodes.forEach((node) => {
+      const label = (node.data as any)?.label;
+      if (label) {
+        outputs[label] = data;
+      } else {
+        outputs.output = data;
+      }
+    });
+  } else if (Object.keys(outputs).length === 0) {
+    outputs.output = data;
+  }
+}


### PR DESCRIPTION
## Summary
- 抽离节点执行、条件分支与输出到独立 `executor` 辅助函数
- `FlowCanvas.execute` 仅负责调度并整合运行中心日志
- 新增执行成功、错误节点及 RunCenter 集成的单元测试

## Testing
- `npm run lint`
- `npm run type-check`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_b_68b9295ea978832a8cbb97777d24fa66