### PR TITLE
feat: 初步接入 orchestrator 支持失败修复流程

### DIFF
--- a/packages/@ai/orchestrator/package.json
+++ b/packages/@ai/orchestrator/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@ai/orchestrator",
+  "version": "0.0.0",
+  "type": "module",
+  "main": "src/index.ts"
+}

--- a/packages/@ai/orchestrator/src/index.ts
+++ b/packages/@ai/orchestrator/src/index.ts
@@ -1,0 +1,3 @@
+export { generateBlueprint } from './planner';
+export { repairFailure } from './repairer';
+export type { FailureContext, ASTPatch } from './repairer';

--- a/packages/@ai/orchestrator/src/planner.ts
+++ b/packages/@ai/orchestrator/src/planner.ts
@@ -1,0 +1,8 @@
+import { parseBlueprintDSL } from '../../../../src/planner';
+
+/**
+ * 基于 DSL 文本生成蓝图描述。
+ */
+export function generateBlueprint(dsl: string) {
+  return parseBlueprintDSL(dsl);
+}

--- a/packages/@ai/orchestrator/src/repairer.ts
+++ b/packages/@ai/orchestrator/src/repairer.ts
@@ -1,0 +1,18 @@
+export interface FailureContext {
+  code: string;
+  logs: string[];
+  input: unknown;
+  output?: unknown;
+}
+
+export interface ASTPatch {
+  code: string;
+}
+
+/**
+ * 根据失败上下文生成 AST 补丁。
+ */
+export function repairFailure(ctx: FailureContext): ASTPatch {
+  // 真实实现中应使用上下文生成补丁，此处返回占位符。
+  return { code: ctx.code };
+}

--- a/packages/@app/services/package.json
+++ b/packages/@app/services/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@app/services",
+  "version": "0.0.0",
+  "type": "module",
+  "main": "src/index.ts",
+  "dependencies": {
+    "@ai/orchestrator": "0.0.0"
+  }
+}

--- a/packages/@app/services/src/commands/applyPatch.ts
+++ b/packages/@app/services/src/commands/applyPatch.ts
@@ -1,0 +1,12 @@
+import { repairFailure, type FailureContext, type ASTPatch } from '@ai/orchestrator';
+
+export type PatchApplier = (code: string) => void;
+
+/**
+ * 接收失败上下文并应用补丁。
+ */
+export function handleFailure(ctx: FailureContext, apply: PatchApplier): ASTPatch {
+  const patch = repairFailure(ctx);
+  apply(patch.code);
+  return patch;
+}

--- a/packages/@app/services/src/commands/applyPatch.ts
+++ b/packages/@app/services/src/commands/applyPatch.ts
@@ -1,11 +1,18 @@
-import { repairFailure, type FailureContext, type ASTPatch } from '@ai/orchestrator';
+import {
+  repairFailure,
+  type FailureContext,
+  type ASTPatch,
+} from '@ai/orchestrator';
 
 export type PatchApplier = (code: string) => void;
 
 /**
  * 接收失败上下文并应用补丁。
  */
-export function handleFailure(ctx: FailureContext, apply: PatchApplier): ASTPatch {
+export function handleFailure(
+  ctx: FailureContext,
+  apply: PatchApplier
+): ASTPatch {
   const patch = repairFailure(ctx);
   apply(patch.code);
   return patch;

--- a/packages/@app/services/src/commands/index.ts
+++ b/packages/@app/services/src/commands/index.ts
@@ -1,0 +1,2 @@
+export { handleFailure } from './applyPatch';
+export type { PatchApplier } from './applyPatch';

--- a/packages/@app/services/src/index.ts
+++ b/packages/@app/services/src/index.ts
@@ -1,0 +1,1 @@
+export * as commands from './commands';

--- a/packages/@core/observability/package.json
+++ b/packages/@core/observability/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@core/observability",
+  "version": "0.0.0",
+  "type": "module",
+  "main": "src/index.ts"
+}

--- a/packages/@core/observability/src/index.ts
+++ b/packages/@core/observability/src/index.ts
@@ -1,0 +1,2 @@
+export * from './logger';
+export * from './trace';

--- a/packages/@core/observability/src/logger.ts
+++ b/packages/@core/observability/src/logger.ts
@@ -1,0 +1,31 @@
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+export interface LogRow {
+  ts: number;
+  level: LogLevel;
+  nodeId: string | undefined;
+  runId: string | undefined;
+  chainId: string | undefined;
+  fields: Record<string, unknown> | undefined;
+}
+
+export interface LoggerContext {
+  nodeId?: string;
+  runId?: string;
+  chainId?: string;
+}
+
+export function createLog(
+  level: LogLevel,
+  ctx: LoggerContext,
+  fields?: Record<string, unknown>
+): LogRow {
+  return {
+    ts: Date.now(),
+    level,
+    nodeId: ctx.nodeId,
+    runId: ctx.runId,
+    chainId: ctx.chainId,
+    fields,
+  };
+}

--- a/packages/@core/observability/src/trace.ts
+++ b/packages/@core/observability/src/trace.ts
@@ -1,0 +1,10 @@
+export interface Trace {
+  chainId: string | undefined;
+  parentId: string | undefined;
+  runId: string | undefined;
+  nodeId: string | undefined;
+}
+
+export function createTrace(trace: Trace): Trace {
+  return trace;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,7 +30,13 @@
       "@/flow/*": ["src/flow/*"],
       "@/nodes/*": ["src/nodes/*"],
       "@/run-center/*": ["src/run-center/*"],
-      "@/utils/*": ["src/utils/*"]
+      "@/utils/*": ["src/utils/*"],
+      "@ai/orchestrator": ["packages/@ai/orchestrator/src"],
+      "@ai/orchestrator/*": ["packages/@ai/orchestrator/src/*"],
+      "@app/services": ["packages/@app/services/src"],
+      "@app/services/*": ["packages/@app/services/src/*"],
+      "@core/observability": ["packages/@core/observability/src"],
+      "@core/observability/*": ["packages/@core/observability/src/*"]
     },
 
     /* Additional type checking */
@@ -38,6 +44,6 @@
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true
   },
-  "include": ["src"],
+  "include": ["src", "packages"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }


### PR DESCRIPTION
## Summary
- 新增 `@ai/orchestrator` 包，提供蓝图生成与补丁接口
- 在 `@app/services` 中加入 `handleFailure` 命令串联失败上下文与补丁应用

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68b933f149c0832a86dbbee9d6d6cb02