### PR TITLE
feat: 实现 workflow web components 与演示页面

### DIFF
--- a/apps/embeds-demo/index.html
+++ b/apps/embeds-demo/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="zh-CN">
   <head>
     <meta charset="UTF-8" />

--- a/apps/embeds-demo/index.html
+++ b/apps/embeds-demo/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Embeds Demo</title>
+  </head>
+  <body>
+    <workflow-node node-id="demo-node"></workflow-node>
+    <script type="module" src="./src/index.ts"></script>
+  </body>
+</html>

--- a/apps/embeds-demo/src/index.ts
+++ b/apps/embeds-demo/src/index.ts
@@ -18,9 +18,15 @@ const node = document.querySelector('workflow-node');
 
 if (node) {
   node.addEventListener('run', (ev) => {
-    window.parent.postMessage({ type: 'run', detail: (ev as CustomEvent).detail }, '*');
+    window.parent.postMessage(
+      { type: 'run', detail: (ev as CustomEvent).detail },
+      '*'
+    );
   });
   node.addEventListener('log', (ev) => {
-    window.parent.postMessage({ type: 'log', detail: (ev as CustomEvent).detail }, '*');
+    window.parent.postMessage(
+      { type: 'log', detail: (ev as CustomEvent).detail },
+      '*'
+    );
   });
 }

--- a/apps/embeds-demo/src/index.ts
+++ b/apps/embeds-demo/src/index.ts
@@ -1,0 +1,26 @@
+import '../../packages/@embeds/wc/src/workflow-node';
+import '../../packages/@embeds/wc/src/workflow-flow';
+
+function handshake() {
+  window.parent.postMessage({ type: 'embeds-demo:ready' }, '*');
+}
+
+window.addEventListener('message', (ev) => {
+  const msg = ev.data;
+  if (msg?.type === 'embeds-demo:init') {
+    // 初始化回调占位
+  }
+});
+
+handshake();
+
+const node = document.querySelector('workflow-node');
+
+if (node) {
+  node.addEventListener('run', (ev) => {
+    window.parent.postMessage({ type: 'run', detail: (ev as CustomEvent).detail }, '*');
+  });
+  node.addEventListener('log', (ev) => {
+    window.parent.postMessage({ type: 'log', detail: (ev as CustomEvent).detail }, '*');
+  });
+}

--- a/packages/@core/observability/package.json
+++ b/packages/@core/observability/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@core/observability",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts"
+}

--- a/packages/@core/observability/src/index.ts
+++ b/packages/@core/observability/src/index.ts
@@ -1,0 +1,3 @@
+export * from './logger';
+export * from './trace';
+export * from './ndjson';

--- a/packages/@core/observability/src/logger.ts
+++ b/packages/@core/observability/src/logger.ts
@@ -1,0 +1,14 @@
+export type LogLevel = 'DEBUG' | 'INFO' | 'WARN' | 'ERROR';
+
+export interface LogRow {
+  ts: number;
+  level: LogLevel;
+  nodeId?: string | undefined;
+  runId?: string | undefined;
+  chainId?: string | undefined;
+  fields?: Record<string, unknown> | undefined;
+}
+
+export function createLog(row: LogRow): LogRow {
+  return row;
+}

--- a/packages/@core/observability/src/ndjson.ts
+++ b/packages/@core/observability/src/ndjson.ts
@@ -1,0 +1,5 @@
+import type { LogRow } from './logger';
+
+export function toNDJSON(row: LogRow): string {
+  return JSON.stringify(row);
+}

--- a/packages/@core/observability/src/trace.ts
+++ b/packages/@core/observability/src/trace.ts
@@ -1,0 +1,10 @@
+export interface Trace {
+  chainId: string;
+  parentId?: string | undefined;
+  runId: string;
+  nodeId?: string | undefined;
+}
+
+export function createTrace(trace: Trace): Trace {
+  return trace;
+}

--- a/packages/@embeds/wc/package.json
+++ b/packages/@embeds/wc/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@embeds/wc",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts"
+}

--- a/packages/@embeds/wc/src/index.ts
+++ b/packages/@embeds/wc/src/index.ts
@@ -1,0 +1,2 @@
+export * from './workflow-node';
+export * from './workflow-flow';

--- a/packages/@embeds/wc/src/workflow-flow.ts
+++ b/packages/@embeds/wc/src/workflow-flow.ts
@@ -1,0 +1,49 @@
+export class WorkflowFlow extends HTMLElement {
+  static get observedAttributes() {
+    return ['flow-id', 'readonly', 'theme'];
+  }
+
+  private runBtn: HTMLButtonElement | null = null;
+
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+  }
+
+  connectedCallback() {
+    this.render();
+  }
+
+  attributeChangedCallback(name: string, _old: string | null, value: string | null) {
+    if (name === 'readonly' && this.runBtn) {
+      this.runBtn.disabled = value !== null;
+    }
+  }
+
+  private render() {
+    this.shadowRoot!.innerHTML = `
+      <section>
+        <slot></slot>
+        <button id="run">Run Flow</button>
+        <pre id="logs"></pre>
+      </section>`;
+    this.runBtn = this.shadowRoot!.getElementById('run') as HTMLButtonElement;
+    this.runBtn.addEventListener('click', () => {
+      if (this.hasAttribute('readonly')) return;
+      this.dispatchEvent(
+        new CustomEvent('run', {
+          detail: { flowId: this.getAttribute('flow-id') },
+        }),
+      );
+    });
+    this.attributeChangedCallback('readonly', null, this.getAttribute('readonly'));
+  }
+
+  appendLog(line: string) {
+    const pre = this.shadowRoot!.getElementById('logs') as HTMLPreElement;
+    pre.textContent += `${line}\n`;
+    this.dispatchEvent(new CustomEvent('log', { detail: line }));
+  }
+}
+
+customElements.define('workflow-flow', WorkflowFlow);

--- a/packages/@embeds/wc/src/workflow-flow.ts
+++ b/packages/@embeds/wc/src/workflow-flow.ts
@@ -14,7 +14,11 @@ export class WorkflowFlow extends HTMLElement {
     this.render();
   }
 
-  attributeChangedCallback(name: string, _old: string | null, value: string | null) {
+  attributeChangedCallback(
+    name: string,
+    _old: string | null,
+    value: string | null
+  ) {
     if (name === 'readonly' && this.runBtn) {
       this.runBtn.disabled = value !== null;
     }
@@ -33,10 +37,14 @@ export class WorkflowFlow extends HTMLElement {
       this.dispatchEvent(
         new CustomEvent('run', {
           detail: { flowId: this.getAttribute('flow-id') },
-        }),
+        })
       );
     });
-    this.attributeChangedCallback('readonly', null, this.getAttribute('readonly'));
+    this.attributeChangedCallback(
+      'readonly',
+      null,
+      this.getAttribute('readonly')
+    );
   }
 
   appendLog(line: string) {

--- a/packages/@embeds/wc/src/workflow-node.ts
+++ b/packages/@embeds/wc/src/workflow-node.ts
@@ -14,7 +14,11 @@ export class WorkflowNode extends HTMLElement {
     this.render();
   }
 
-  attributeChangedCallback(name: string, _old: string | null, value: string | null) {
+  attributeChangedCallback(
+    name: string,
+    _old: string | null,
+    value: string | null
+  ) {
     if (name === 'readonly' && this.runBtn) {
       this.runBtn.disabled = value !== null;
     }
@@ -33,10 +37,14 @@ export class WorkflowNode extends HTMLElement {
       this.dispatchEvent(
         new CustomEvent('run', {
           detail: { nodeId: this.getAttribute('node-id') },
-        }),
+        })
       );
     });
-    this.attributeChangedCallback('readonly', null, this.getAttribute('readonly'));
+    this.attributeChangedCallback(
+      'readonly',
+      null,
+      this.getAttribute('readonly')
+    );
   }
 
   appendLog(line: string) {

--- a/packages/@embeds/wc/src/workflow-node.ts
+++ b/packages/@embeds/wc/src/workflow-node.ts
@@ -1,0 +1,49 @@
+export class WorkflowNode extends HTMLElement {
+  static get observedAttributes() {
+    return ['node-id', 'readonly', 'theme'];
+  }
+
+  private runBtn: HTMLButtonElement | null = null;
+
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+  }
+
+  connectedCallback() {
+    this.render();
+  }
+
+  attributeChangedCallback(name: string, _old: string | null, value: string | null) {
+    if (name === 'readonly' && this.runBtn) {
+      this.runBtn.disabled = value !== null;
+    }
+  }
+
+  private render() {
+    this.shadowRoot!.innerHTML = `
+      <section>
+        <slot name="header"></slot>
+        <button id="run">Run</button>
+        <pre id="logs"></pre>
+      </section>`;
+    this.runBtn = this.shadowRoot!.getElementById('run') as HTMLButtonElement;
+    this.runBtn.addEventListener('click', () => {
+      if (this.hasAttribute('readonly')) return;
+      this.dispatchEvent(
+        new CustomEvent('run', {
+          detail: { nodeId: this.getAttribute('node-id') },
+        }),
+      );
+    });
+    this.attributeChangedCallback('readonly', null, this.getAttribute('readonly'));
+  }
+
+  appendLog(line: string) {
+    const pre = this.shadowRoot!.getElementById('logs') as HTMLPreElement;
+    pre.textContent += `${line}\n`;
+    this.dispatchEvent(new CustomEvent('log', { detail: line }));
+  }
+}
+
+customElements.define('workflow-node', WorkflowNode);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,7 +30,8 @@
       "@/flow/*": ["src/flow/*"],
       "@/nodes/*": ["src/nodes/*"],
       "@/run-center/*": ["src/run-center/*"],
-      "@/utils/*": ["src/utils/*"]
+      "@/utils/*": ["src/utils/*"],
+      "@core/observability": ["packages/@core/observability/src"]
     },
 
     /* Additional type checking */
@@ -38,6 +39,6 @@
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true
   },
-  "include": ["src"],
+  "include": ["src", "packages"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }


### PR DESCRIPTION
## Summary
- 实现 `<workflow-node>` 与 `<workflow-flow>`，支持 `node-id`、`readonly`
- 通过 `run`/`log` 自定义事件与宿主通信
- 新增 embeds demo 页面并接入 `postMessage` 握手

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68b933ef75f4832a8af55a98f5909bd8