### PR TITLE
feat: 使用 Ajv 以 JSON Schema 校验运行输入输出

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "superflow",
       "version": "0.1.0",
       "dependencies": {
+        "ajv": "^8.12.0",
         "comlink": "^4.4.1",
         "dexie": "^3.2.4",
         "react": "^18.2.0",
@@ -966,6 +967,23 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -976,6 +994,13 @@
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
       "version": "3.1.2",
@@ -2551,16 +2576,15 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
@@ -3429,6 +3453,23 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/eslint/node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -3439,6 +3480,13 @@
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/eslint/node_modules/minimatch": {
       "version": "3.1.2",
@@ -3551,7 +3599,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -3597,6 +3644,22 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
       "version": "1.19.1",
@@ -4339,10 +4402,9 @@
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
@@ -5072,6 +5134,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve-from": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "react-dom": "^18.2.0",
     "reactflow": "^11.11.0",
     "ulid": "^2.3.0",
-    "zod": "^3.22.4"
+    "zod": "^3.22.4",
+    "ajv": "^8.12.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.40.0",

--- a/packages/@core/domain/schemas/exec-request.schema.json
+++ b/packages/@core/domain/schemas/exec-request.schema.json
@@ -1,0 +1,41 @@
+{
+  "$id": "https://superflow.dev/schemas/exec-request.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "kind": { "const": "EXEC" },
+    "runId": { "type": "string", "minLength": 26, "maxLength": 26 },
+    "nodeId": { "type": "string" },
+    "flowId": { "type": "string" },
+    "code": { "type": "string" },
+    "language": { "enum": ["js", "ts"] },
+    "input": {},
+    "controls": {
+      "type": "object",
+      "properties": {
+        "timeoutMs": { "type": "integer", "minimum": 1 },
+        "retries": { "type": "integer", "minimum": 0 }
+      },
+      "required": [],
+      "additionalProperties": false
+    },
+    "env": {
+      "type": "object",
+      "additionalProperties": { "type": "string" }
+    },
+    "capabilities": {
+      "type": "array",
+      "items": { "type": "string" }
+    }
+  },
+  "required": [
+    "kind",
+    "runId",
+    "nodeId",
+    "flowId",
+    "code",
+    "language",
+    "input"
+  ],
+  "additionalProperties": false
+}

--- a/packages/@core/domain/schemas/exec-result.schema.json
+++ b/packages/@core/domain/schemas/exec-result.schema.json
@@ -1,0 +1,10 @@
+{
+  "$id": "https://superflow.dev/schemas/exec-result.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "output": {}
+  },
+  "required": ["output"],
+  "additionalProperties": true
+}

--- a/packages/@core/domain/types.ts
+++ b/packages/@core/domain/types.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+
+// 仅用于类型推断，契约以 JSON Schema 为准
+export const ExecRequestSchema = z.object({
+  kind: z.literal('EXEC'),
+  runId: z.string().min(26).max(26),
+  nodeId: z.string(),
+  flowId: z.string(),
+  code: z.string(),
+  language: z.enum(['js', 'ts']),
+  input: z.unknown(),
+  controls: z
+    .object({
+      timeoutMs: z.number().int().positive().optional(),
+      retries: z.number().int().nonnegative().optional(),
+    })
+    .optional(),
+  env: z.record(z.string()).optional(),
+  capabilities: z.array(z.string()).optional(),
+});
+
+export type ExecRequest = z.infer<typeof ExecRequestSchema>;

--- a/packages/@core/runtime/__tests__/executor.test.ts
+++ b/packages/@core/runtime/__tests__/executor.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import inputSchema from '@core/domain/schemas/exec-request.schema.json';
+import outputSchema from '@core/domain/schemas/exec-result.schema.json';
+import { createExecutor } from '@core/runtime';
+
+describe('createExecutor', () => {
+  const run = createExecutor({ input: inputSchema, output: outputSchema });
+
+  it('通过合法数据', async () => {
+    const result = await run(async (req) => ({ output: req.input }), {
+      kind: 'EXEC',
+      runId: '0123456789abcdefghijklmnop',
+      nodeId: 'node-1',
+      flowId: 'flow-1',
+      code: 'return input',
+      language: 'js',
+      input: 1,
+    });
+    expect(result).toEqual({ output: 1 });
+  });
+
+  it('拒绝非法输入', async () => {
+    await expect(
+      run(async () => ({ output: 1 }), { invalid: true } as any)
+    ).rejects.toThrow();
+  });
+});

--- a/packages/@core/runtime/index.ts
+++ b/packages/@core/runtime/index.ts
@@ -1,0 +1,24 @@
+import Ajv, { AnySchema } from 'ajv';
+
+export function createExecutor(schemas: {
+  input: AnySchema;
+  output: AnySchema;
+}) {
+  const ajv = new Ajv();
+  const validateInput = ajv.compile(schemas.input);
+  const validateOutput = ajv.compile(schemas.output);
+
+  return async function run(
+    handler: (input: any) => Promise<any> | any,
+    input: unknown
+  ): Promise<any> {
+    if (!validateInput(input)) {
+      throw new Error(ajv.errorsText(validateInput.errors));
+    }
+    const result = await handler(input);
+    if (!validateOutput(result)) {
+      throw new Error(ajv.errorsText(validateOutput.errors));
+    }
+    return result;
+  };
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,7 +30,8 @@
       "@/flow/*": ["src/flow/*"],
       "@/nodes/*": ["src/nodes/*"],
       "@/run-center/*": ["src/run-center/*"],
-      "@/utils/*": ["src/utils/*"]
+      "@/utils/*": ["src/utils/*"],
+      "@core/*": ["packages/@core/*"]
     },
 
     /* Additional type checking */
@@ -38,6 +39,6 @@
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true
   },
-  "include": ["src"],
+  "include": ["src", "packages"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -40,6 +40,7 @@ export default defineConfig({
       '@/nodes': resolve(__dirname, 'src/nodes'),
       '@/run-center': resolve(__dirname, 'src/run-center'),
       '@/utils': resolve(__dirname, 'src/utils'),
+      '@core': resolve(__dirname, 'packages/@core'),
     },
   },
 });


### PR DESCRIPTION
## Summary
- 引入 `ajv` 并新增 `packages/@core` 模块
- 以 JSON Schema 维护执行请求/结果契约
- 在 runtime 中使用 Ajv 校验 `input`/`output`

## Testing
- `npm run lint`
- `npm test`
- `npm run type-check`
- `npm run format:check`


------
https://chatgpt.com/codex/tasks/task_b_68b933eca610832a983a33fcb8421bbd