### PR TITLE
feat: structured logs with export

### DIFF
--- a/packages/@core/observability/src/logger.ts
+++ b/packages/@core/observability/src/logger.ts
@@ -1,0 +1,14 @@
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+export interface LogRow {
+  ts: number;
+  level: LogLevel;
+  runId?: string | undefined;
+  chainId?: string | undefined;
+  nodeId?: string | undefined;
+  fields?: Record<string, unknown> | undefined;
+}
+
+export function createLog(row: LogRow): LogRow {
+  return row;
+}

--- a/packages/@core/observability/src/trace.ts
+++ b/packages/@core/observability/src/trace.ts
@@ -1,0 +1,10 @@
+export interface Trace {
+  chainId: string;
+  runId: string;
+  parentId?: string | undefined;
+  nodeId?: string | undefined;
+}
+
+export function createTrace(data: Trace): Trace {
+  return data;
+}

--- a/src/flow/FlowCanvas.ts
+++ b/src/flow/FlowCanvas.ts
@@ -700,7 +700,12 @@ export class FlowCanvas {
     runCenter?: {
       addLog: (
         runId: string,
-        log: { level: string; message: string }
+        log: {
+          level: string;
+          chainId: string;
+          fields: Record<string, unknown>;
+          nodeId?: string;
+        }
       ) => Promise<void>;
       updateRunStatus: (
         runId: string,

--- a/src/flow/FlowCanvas.ts
+++ b/src/flow/FlowCanvas.ts
@@ -729,7 +729,8 @@ export class FlowCanvas {
       if (runCenter && runId) {
         await runCenter.addLog(runId, {
           level: 'info',
-          message: `流程开始执行: ${executionId}`,
+          fields: { message: `流程开始执行: ${executionId}` },
+          chainId: runId,
         });
       }
 
@@ -745,7 +746,8 @@ export class FlowCanvas {
       if (runCenter && runId) {
         await runCenter.addLog(runId, {
           level: 'info',
-          message: `流程执行完成: ${executionId}`,
+          fields: { message: `流程执行完成: ${executionId}` },
+          chainId: runId,
         });
         await runCenter.updateRunStatus(runId, 'completed', {
           output: outputs,
@@ -765,7 +767,12 @@ export class FlowCanvas {
       if (runCenter && runId) {
         await runCenter.addLog(runId, {
           level: 'error',
-          message: `流程执行失败: ${error instanceof Error ? error.message : String(error)}`,
+          fields: {
+            message: `流程执行失败: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          },
+          chainId: runId,
         });
         await runCenter.updateRunStatus(runId, 'failed', {
           error: error instanceof Error ? error.message : String(error),

--- a/src/run-center/RunCenterService.ts
+++ b/src/run-center/RunCenterService.ts
@@ -102,7 +102,7 @@ export class RunCenterService {
       runId,
       chainId: log.chainId ?? runId,
       level: log.level,
-      nodeId: log.nodeId,
+      ...(log.nodeId ? { nodeId: log.nodeId } : {}),
       fields: log.fields || {},
     };
 

--- a/src/run-center/__tests__/RunCenterPage.test.tsx
+++ b/src/run-center/__tests__/RunCenterPage.test.tsx
@@ -1,3 +1,4 @@
+import 'fake-indexeddb/auto';
 import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import {
@@ -76,8 +77,8 @@ describe('RunCenterPage', () => {
                 id: l.id,
                 node: l.nodeId || 'N',
                 status: l.level === 'error' ? 'failed' : 'success',
-                message: l.message,
-                error: l.level === 'error' ? l.message : undefined,
+                message: l.fields.message as string,
+                error: l.level === 'error' ? (l.fields.message as string) : undefined,
               },
             ]);
           }
@@ -100,13 +101,13 @@ describe('RunCenterPage', () => {
         await service.updateRunStatus(run.id, 'running');
         await service.addLog(run.id, {
           level: 'info',
-          message: 'started',
           nodeId: 'A',
+          fields: { message: 'started' },
         });
         await service.addLog(run.id, {
           level: 'error',
-          message: 'boom',
           nodeId: 'B',
+          fields: { message: 'boom' },
         });
         await service.updateRunStatus(run.id, 'failed');
       });

--- a/src/run-center/__tests__/RunCenterPage.test.tsx
+++ b/src/run-center/__tests__/RunCenterPage.test.tsx
@@ -78,7 +78,9 @@ describe('RunCenterPage', () => {
                 node: l.nodeId || 'N',
                 status: l.level === 'error' ? 'failed' : 'success',
                 message: l.fields.message as string,
-                error: l.level === 'error' ? (l.fields.message as string) : undefined,
+                ...(l.level === 'error'
+                  ? { error: l.fields.message as string }
+                  : {}),
               },
             ]);
           }
@@ -102,11 +104,13 @@ describe('RunCenterPage', () => {
         await service.addLog(run.id, {
           level: 'info',
           nodeId: 'A',
+          chainId: run.id,
           fields: { message: 'started' },
         });
         await service.addLog(run.id, {
           level: 'error',
           nodeId: 'B',
+          chainId: run.id,
           fields: { message: 'boom' },
         });
         await service.updateRunStatus(run.id, 'failed');

--- a/src/run-center/__tests__/module.test.ts
+++ b/src/run-center/__tests__/module.test.ts
@@ -62,7 +62,7 @@ describe('Run Center Module', () => {
 
       const logs = await runCenter.getLogs(runId);
       expect(logs.length).toBe(1);
-      expect(logs[0].event).toBe('node_executed');
+      expect(logs[0].fields.message).toBe('node_executed');
     });
 
     it('应该支持不同日志级别', async () => {
@@ -88,8 +88,8 @@ describe('Run Center Module', () => {
       await runCenter.log(runId, { level: 'info', event: 'second' });
 
       const logs = await runCenter.getLogs(runId);
-      expect(logs[0].event).toBe('first');
-      expect(logs[1].event).toBe('second');
+      expect(logs[0].fields.message).toBe('first');
+      expect(logs[1].fields.message).toBe('second');
       expect(logs[1].ts).toBeGreaterThan(logs[0].ts);
     });
   });
@@ -141,7 +141,7 @@ describe('Run Center Module', () => {
 
       await new Promise<void>((resolve) => {
         runCenter.streamLogs(runId, (log: any) => {
-          expect(log.event).toBe('stream_test');
+          expect(log.fields.message).toBe('stream_test');
           resolve();
         });
 

--- a/src/run-center/__tests__/reconnect.integration.test.ts
+++ b/src/run-center/__tests__/reconnect.integration.test.ts
@@ -1,3 +1,4 @@
+import 'fake-indexeddb/auto';
 import { describe, it, expect, vi } from 'vitest';
 import { RunCenterClient } from '../RunCenterClient';
 import { RunCenterService } from '../RunCenterService';

--- a/src/run-center/__tests__/service.integration.test.ts
+++ b/src/run-center/__tests__/service.integration.test.ts
@@ -43,6 +43,7 @@ describe('RunCenter Service integration', () => {
     await service.updateRunStatus(runId, 'running');
     await service.addLog(runId, {
       level: 'info',
+      chainId: runId,
       fields: { message: 'started' },
     });
 
@@ -53,7 +54,7 @@ describe('RunCenter Service integration', () => {
     const exported = await service.exportLogs(runId);
     const lines = exported.trim().split('\n');
     expect(lines.length).toBe(1);
-    const obj = JSON.parse(lines[0]);
+    const obj = JSON.parse(lines[0]!);
     expect(obj.fields.message).toBe('started');
   });
 });

--- a/src/run-center/__tests__/service.integration.test.ts
+++ b/src/run-center/__tests__/service.integration.test.ts
@@ -1,3 +1,4 @@
+import 'fake-indexeddb/auto';
 import { describe, it, expect, vi } from 'vitest';
 import { RunCenterService } from '../RunCenterService';
 import { RunCenterClient } from '../RunCenterClient';
@@ -40,10 +41,19 @@ describe('RunCenter Service integration', () => {
     const runId = await page.startRun('flow1');
 
     await service.updateRunStatus(runId, 'running');
-    await service.addLog(runId, { level: 'info', message: 'started' });
+    await service.addLog(runId, {
+      level: 'info',
+      fields: { message: 'started' },
+    });
 
     expect(page.getStatus()).toBe('running');
     expect(page.getLogs().length).toBe(1);
-    expect(page.getLogs()[0].message).toBe('started');
+    expect(page.getLogs()[0].fields.message).toBe('started');
+
+    const exported = await service.exportLogs(runId);
+    const lines = exported.trim().split('\n');
+    expect(lines.length).toBe(1);
+    const obj = JSON.parse(lines[0]);
+    expect(obj.fields.message).toBe('started');
   });
 });

--- a/src/run-center/types.ts
+++ b/src/run-center/types.ts
@@ -50,12 +50,12 @@ export interface RunProgress {
  */
 export interface RunLog {
   id: string;
-  timestamp: number;
+  ts: number;
   level: 'debug' | 'info' | 'warn' | 'error';
-  message: string;
   nodeId?: string;
-  data?: unknown;
-  traceId?: string;
+  runId: string;
+  chainId: string;
+  fields: Record<string, unknown>;
 }
 
 /**

--- a/src/shared/db/index.ts
+++ b/src/shared/db/index.ts
@@ -5,7 +5,7 @@ import type { StorageAdapter, StorageTransaction } from '../types/storage';
  * 数据库版本
  * 修改表结构时请增加版本号并添加迁移逻辑
  */
-export const DB_VERSION = 3;
+export const DB_VERSION = 4;
 
 /**
  * 运行记录表结构
@@ -28,10 +28,10 @@ export interface LogRecord {
   id: string;
   runId: string;
   ts: number;
-  level: 'info' | 'warn' | 'error';
-  event: string;
-  data?: unknown;
-  traceId?: string;
+  level: 'debug' | 'info' | 'warn' | 'error';
+  nodeId?: string;
+  chainId: string;
+  fields: Record<string, unknown>;
 }
 
 /**
@@ -125,6 +125,15 @@ class SuperflowDB extends Dexie {
     this.version(3).stores({
       runs: 'id, flowId, startedAt, finishedAt, status, traceId',
       logs: 'id, runId, ts, level, event, traceId',
+      versions: 'id, nodeId, createdAt, author, version',
+      flows: 'id, name, createdAt, updatedAt, version',
+      nodes: 'id, kind, name, version, createdAt, updatedAt, author',
+      kv: 'key, createdAt, updatedAt, expiresAt, namespace',
+    });
+
+    this.version(4).stores({
+      runs: 'id, flowId, startedAt, finishedAt, status, traceId',
+      logs: 'id, runId, chainId, nodeId, ts, level',
       versions: 'id, nodeId, createdAt, author, version',
       flows: 'id, name, createdAt, updatedAt, version',
       nodes: 'id, kind, name, version, createdAt, updatedAt, author',


### PR DESCRIPTION
## Summary
- 使用 {ts, level, nodeId, runId, chainId, fields} 结构统一运行日志
- RunCenterService 写入 Dexie 时补齐 chainId 并新增导出 NDJSON
- 调整数据库 schema 以支持新日志字段

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b933b76db4832a9140da2a862d68ab