### PR TITLE
feat: Dexie 日志与 NDJSON 导出

### DIFF
--- a/packages/@core/observability/src/logger.ts
+++ b/packages/@core/observability/src/logger.ts
@@ -1,0 +1,88 @@
+import Dexie, { type Table } from 'dexie';
+
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+export interface LogEntry {
+  ts: number;
+  level: LogLevel;
+  nodeId?: string;
+  runId?: string;
+  chainId?: string;
+  fields?: Record<string, unknown>;
+}
+
+interface LogRow extends LogEntry {
+  id?: number;
+}
+
+class ObservabilityDB extends Dexie {
+  logs!: Table<LogRow, number>;
+
+  constructor() {
+    super('observability');
+    this.version(1).stores({
+      logs: '++id, runId, nodeId, chainId, level, ts',
+    });
+  }
+}
+
+export const db = new ObservabilityDB();
+
+export interface LoggerOptions {
+  runId?: string;
+  nodeId?: string;
+  chainId?: string;
+}
+
+export class Logger {
+  private context: LoggerOptions;
+
+  constructor(context: LoggerOptions = {}) {
+    this.context = context;
+  }
+
+  child(options: LoggerOptions): Logger {
+    return new Logger({ ...this.context, ...options });
+  }
+
+  private async write(
+    level: LogLevel,
+    entry: Omit<LogEntry, 'level' | 'ts'> & { ts?: number }
+  ): Promise<void> {
+    const log: LogRow = {
+      ts: entry.ts ?? Date.now(),
+      level,
+      nodeId: entry.nodeId ?? this.context.nodeId,
+      runId: entry.runId ?? this.context.runId,
+      chainId: entry.chainId ?? this.context.chainId,
+      fields: entry.fields,
+    };
+    await db.logs.add(log);
+  }
+
+  debug(
+    entry: Omit<LogEntry, 'level' | 'ts'> & { ts?: number } = {}
+  ): Promise<void> {
+    return this.write('debug', entry);
+  }
+
+  info(
+    entry: Omit<LogEntry, 'level' | 'ts'> & { ts?: number } = {}
+  ): Promise<void> {
+    return this.write('info', entry);
+  }
+
+  warn(
+    entry: Omit<LogEntry, 'level' | 'ts'> & { ts?: number } = {}
+  ): Promise<void> {
+    return this.write('warn', entry);
+  }
+
+  error(
+    entry: Omit<LogEntry, 'level' | 'ts'> & { ts?: number } = {}
+  ): Promise<void> {
+    return this.write('error', entry);
+  }
+}
+
+export const logger = new Logger();

--- a/packages/@core/observability/src/ndjson.ts
+++ b/packages/@core/observability/src/ndjson.ts
@@ -1,0 +1,10 @@
+import { db } from './logger';
+
+export async function exportNDJSON(runId: string): Promise<string> {
+  const logs = await db.logs.where('runId').equals(runId).sortBy('ts');
+  return logs
+    .map(({ ts, level, nodeId, runId: r, chainId, fields }) =>
+      JSON.stringify({ ts, level, nodeId, runId: r, chainId, fields })
+    )
+    .join('\n');
+}

--- a/packages/@core/observability/src/trace.ts
+++ b/packages/@core/observability/src/trace.ts
@@ -1,0 +1,21 @@
+import { ulid } from 'ulid';
+
+export interface Trace {
+  chainId: string;
+  parentId?: string;
+  runId: string;
+  nodeId?: string;
+}
+
+export function createTrace(
+  runId: string,
+  nodeId?: string,
+  parentId?: string
+): Trace {
+  return {
+    chainId: ulid(),
+    parentId,
+    runId,
+    nodeId,
+  };
+}


### PR DESCRIPTION
## 摘要
- 新增基于 Dexie 的日志记录器，统一日志结构
- 增加 trace 工具生成链路信息
- 支持按 run 导出 NDJSON 格式日志

## 测试
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b933ee5028832abed9009cc50d3b55