### PR TITLE
feat(run-center): 引入执行器 worker 与 RunnerClient

### DIFF
--- a/src/run-center/RunnerClient.ts
+++ b/src/run-center/RunnerClient.ts
@@ -1,0 +1,62 @@
+import * as Comlink from 'comlink';
+import type { ExecRequest, ExecEvent } from '@/shared/types/runtime';
+
+export type EventCallback = (event: ExecEvent) => void;
+
+export class RunnerClient {
+  async run(
+    req: ExecRequest,
+    onEvent: EventCallback,
+    options?: { signal?: AbortSignal }
+  ): Promise<void> {
+    const worker = new Worker(
+      new URL('./executor.worker.ts', import.meta.url),
+      { type: 'module' }
+    );
+    const api = Comlink.wrap<{
+      exec: (r: ExecRequest, cb: (e: ExecEvent) => void) => Promise<void>;
+    }>(worker);
+
+    const hardTimeout = req.controls?.timeoutMs ?? 15000;
+    const cb = Comlink.proxy((e: ExecEvent) => {
+      if (e.kind === 'LOG') {
+        const { level, event, data } = e;
+        (console as any)[level]?.(event, data);
+      }
+      onEvent(e);
+    });
+
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    return new Promise(async (resolve, reject) => {
+      const cleanup = () => {
+        if (timeoutId) clearTimeout(timeoutId);
+        worker.terminate();
+      };
+      timeoutId = setTimeout(() => {
+        worker.terminate();
+        onEvent({
+          kind: 'LOG',
+          runId: req.runId,
+          ts: Date.now(),
+          level: 'error',
+          event: `Timeout ${hardTimeout}ms`,
+        });
+        reject(new Error(`Timeout ${hardTimeout}ms`));
+      }, hardTimeout);
+
+      options?.signal?.addEventListener('abort', () => {
+        worker.terminate();
+        reject(new DOMException('Aborted', 'AbortError'));
+      });
+
+      try {
+        await api.exec(req, cb);
+        resolve();
+      } catch (err) {
+        reject(err);
+      } finally {
+        cleanup();
+      }
+    });
+  }
+}

--- a/src/run-center/executor.worker.ts
+++ b/src/run-center/executor.worker.ts
@@ -1,0 +1,65 @@
+import * as Comlink from 'comlink';
+import type { ExecRequest, ExecEvent } from '@/shared/types/runtime';
+
+export type EventCallback = (event: ExecEvent) => void;
+
+async function loadModuleFromCode(code: string): Promise<any> {
+  const blob = new Blob([code], { type: 'text/javascript' });
+  const url = URL.createObjectURL(blob);
+  try {
+    return await import(/* @vite-ignore */ url);
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+}
+
+async function exec(req: ExecRequest, cb: Comlink.Remote<EventCallback>) {
+  const ts = Date.now();
+  await cb({ kind: 'STARTED', runId: req.runId, ts });
+  try {
+    const mod = await loadModuleFromCode(req.code);
+    const handler = mod?.handler;
+    if (typeof handler !== 'function') {
+      throw new Error('handler is not exported as a function');
+    }
+    const started = performance.now();
+    const ctx = {
+      signal: new AbortController().signal,
+      logger: {
+        debug: (event: string, data?: unknown) =>
+          cb({ kind: 'LOG', runId: req.runId, ts: Date.now(), level: 'debug', event, data }),
+        info: (event: string, data?: unknown) =>
+          cb({ kind: 'LOG', runId: req.runId, ts: Date.now(), level: 'info', event, data }),
+        warn: (event: string, data?: unknown) =>
+          cb({ kind: 'LOG', runId: req.runId, ts: Date.now(), level: 'warn', event, data }),
+        error: (event: string, data?: unknown) =>
+          cb({ kind: 'LOG', runId: req.runId, ts: Date.now(), level: 'error', event, data }),
+      },
+      env: req.env ?? {},
+      traceId: '' as any,
+    } as const;
+
+    const output = await handler(req.input, ctx);
+    const durationMs = Math.round(performance.now() - started);
+    await cb({
+      kind: 'RESULT',
+      runId: req.runId,
+      ts: Date.now(),
+      durationMs,
+      output,
+    });
+  } catch (err) {
+    await cb({
+      kind: 'LOG',
+      runId: req.runId,
+      ts: Date.now(),
+      level: 'error',
+      event: err instanceof Error ? err.message : String(err),
+    });
+    throw err;
+  }
+}
+
+Comlink.expose({ exec });
+
+export {}; // ensure module

--- a/src/run-center/index.ts
+++ b/src/run-center/index.ts
@@ -3,6 +3,7 @@ export { RunCenterService } from './RunCenterService';
 export { RunCenterPage } from './RunCenterPage';
 export type { NodeLog } from './RunCenterPage';
 export { PreviewRunner } from './PreviewRunner';
+export { RunnerClient } from './RunnerClient';
 export type {
   RunRecord,
   RunLog,

--- a/src/run-center/preview-runner.worker.ts
+++ b/src/run-center/preview-runner.worker.ts
@@ -1,5 +1,9 @@
 /// <reference lib="webworker" />
 
+import { RunnerClient } from './RunnerClient';
+import type { ExecRequest, ExecEvent } from '@/shared/types/runtime';
+import { ulid } from 'ulid';
+
 interface RunRequest {
   id: string;
   fnCode: string;
@@ -13,18 +17,39 @@ interface RunResponse {
 }
 
 const ctx: any = self;
+const runner = new RunnerClient();
 
 ctx.onmessage = async (event: MessageEvent<RunRequest>) => {
   const { id, fnCode, args } = event.data;
   try {
-    const fn = Function('return (' + fnCode + ')')();
-    const result = await fn(...(Array.isArray(args) ? args : []));
-    ctx.postMessage({ id, result } as RunResponse);
+    const code = `export async function handler(input){ const fn = (${fnCode}); return await fn(...(Array.isArray(input) ? input : [])); }`;
+    const req: ExecRequest = {
+      kind: 'EXEC',
+      runId: ulid(),
+      nodeId: 'preview',
+      flowId: 'preview',
+      code,
+      language: 'js',
+      input: args,
+    };
+    let output: unknown;
+    await runner.run(req, (ev: ExecEvent) => {
+      if (ev.kind === 'RESULT') {
+        output = ev.output;
+      }
+    });
+    ctx.postMessage({ id, result: output } as RunResponse);
   } catch (err) {
-    ctx.postMessage({
-      id,
-      error: err instanceof Error ? err.message : String(err),
-    } as RunResponse);
+    try {
+      const fn = Function('return (' + fnCode + ')')();
+      const result = await fn(...(Array.isArray(args) ? args : []));
+      ctx.postMessage({ id, result } as RunResponse);
+    } catch (err2) {
+      ctx.postMessage({
+        id,
+        error: err2 instanceof Error ? err2.message : String(err2),
+      } as RunResponse);
+    }
   }
 };
 

--- a/src/shared/types/runtime.ts
+++ b/src/shared/types/runtime.ts
@@ -115,6 +115,7 @@ export const ExecEventSchema = z.union([
   LogEventSchema,
   ResultEventSchema,
 ]);
+export type ExecEvent = z.infer<typeof ExecEventSchema>;
 
 // 别名：NodeContext 等同 WorkerContext
 export type NodeContext = WorkerContext;


### PR DESCRIPTION
## Summary
- 增加 `executor.worker`，通过 Comlink 执行代码并输出事件
- 新增 `RunnerClient`，封装超时、Abort 与日志转发
- `preview-runner.worker` 改为使用执行器运行代码，失败时回退到 `Function`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b933ba7794832aae65a6c2c4ac4171