### PR TITLE
feat: 将运行中心持久化并支持日志导出

### DIFF
--- a/packages/@core/observability/src/index.ts
+++ b/packages/@core/observability/src/index.ts
@@ -1,0 +1,2 @@
+export * from './logger';
+export * from './trace';

--- a/packages/@core/observability/src/logger.ts
+++ b/packages/@core/observability/src/logger.ts
@@ -1,0 +1,34 @@
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+export interface LogRow {
+  ts: number;
+  level: LogLevel;
+  runId?: string;
+  chainId?: string;
+  nodeId?: string;
+  fields?: Record<string, unknown>;
+}
+
+export type LogTransport = (row: LogRow) => void;
+
+export function createLogger(transport: LogTransport) {
+  return function log(
+    level: LogLevel,
+    context: {
+      runId?: string;
+      chainId?: string;
+      nodeId?: string;
+      fields?: Record<string, unknown>;
+    } = {}
+  ): void {
+    const row: LogRow = {
+      ts: Date.now(),
+      level,
+      ...(context.runId && { runId: context.runId }),
+      ...(context.chainId && { chainId: context.chainId }),
+      ...(context.nodeId && { nodeId: context.nodeId }),
+      ...(context.fields && { fields: context.fields }),
+    };
+    transport(row);
+  };
+}

--- a/packages/@core/observability/src/trace.ts
+++ b/packages/@core/observability/src/trace.ts
@@ -1,0 +1,15 @@
+export interface Trace {
+  chainId: string;
+  runId: string;
+  parentId?: string;
+  nodeId?: string;
+}
+
+export function createTrace(input: Trace): Trace {
+  return {
+    chainId: input.chainId,
+    runId: input.runId,
+    ...(input.parentId && { parentId: input.parentId }),
+    ...(input.nodeId && { nodeId: input.nodeId }),
+  };
+}

--- a/packages/@core/observability/tsconfig.json
+++ b/packages/@core/observability/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "composite": true
+  },
+  "include": ["src"]
+}

--- a/src/run-center/RunCenter.tsx
+++ b/src/run-center/RunCenter.tsx
@@ -62,6 +62,7 @@ export class RunCenter {
     const runId = generateId();
     const run: RunRecord = {
       id: runId,
+      chainId: generateId(),
       flowId,
       status: 'running',
       startTime: Date.now(),

--- a/src/run-center/RunCenter.tsx
+++ b/src/run-center/RunCenter.tsx
@@ -201,6 +201,7 @@ export class RunCenter {
     const runId = generateId();
     const run: RunRecord = {
       id: runId,
+      chainId: generateId(),
       flowId,
       status: 'running',
       startTime: Date.now(),

--- a/src/run-center/RunCenterService.ts
+++ b/src/run-center/RunCenterService.ts
@@ -132,7 +132,7 @@ export class RunCenterService {
       level: newLog.level,
       event: newLog.message,
       data: newLog.data,
-      traceId: run?.chainId,
+      ...(run?.chainId ? { traceId: run.chainId } : {}),
     });
 
     this.broadcast(runId, { type: 'log', log: newLog });

--- a/src/run-center/__tests__/RunCenterPage.test.tsx
+++ b/src/run-center/__tests__/RunCenterPage.test.tsx
@@ -1,3 +1,4 @@
+import 'fake-indexeddb/auto';
 import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import {

--- a/src/run-center/__tests__/reconnect.integration.test.ts
+++ b/src/run-center/__tests__/reconnect.integration.test.ts
@@ -1,3 +1,4 @@
+import 'fake-indexeddb/auto';
 import { describe, it, expect, vi } from 'vitest';
 import { RunCenterClient } from '../RunCenterClient';
 import { RunCenterService } from '../RunCenterService';

--- a/src/run-center/__tests__/service.integration.test.ts
+++ b/src/run-center/__tests__/service.integration.test.ts
@@ -1,3 +1,4 @@
+import 'fake-indexeddb/auto';
 import { describe, it, expect, vi } from 'vitest';
 import { RunCenterService } from '../RunCenterService';
 import { RunCenterClient } from '../RunCenterClient';

--- a/src/run-center/types.ts
+++ b/src/run-center/types.ts
@@ -8,6 +8,7 @@
  */
 export interface RunRecord {
   id: string;
+  chainId: string;
   flowId: string;
   status: RunStatus;
   startTime: number;

--- a/src/shared/db/index.ts
+++ b/src/shared/db/index.ts
@@ -322,6 +322,19 @@ export async function importData(
 }
 
 /**
+ * 导出日志为 NDJSON
+ */
+export async function exportLogsNDJSON(
+  db: SuperflowDB,
+  runId?: string
+): Promise<string> {
+  const logs = runId
+    ? await db.logs.where('runId').equals(runId).toArray()
+    : await db.logs.toArray();
+  return logs.map((log) => JSON.stringify(log)).join('\n');
+}
+
+/**
  * 键值存储封装
  */
 export class KVStore {

--- a/src/shared/db/index.ts
+++ b/src/shared/db/index.ts
@@ -15,7 +15,12 @@ export interface RunRecord {
   flowId: string;
   startedAt: number;
   finishedAt?: number;
-  status: 'success' | 'failed' | 'running' | 'cancelled';
+  status:
+    | 'pending'
+    | 'running'
+    | 'completed'
+    | 'failed'
+    | 'cancelled';
   traceId: string;
   error?: string;
   metadata?: Record<string, unknown>;
@@ -28,7 +33,7 @@ export interface LogRecord {
   id: string;
   runId: string;
   ts: number;
-  level: 'info' | 'warn' | 'error';
+  level: 'debug' | 'info' | 'warn' | 'error';
   event: string;
   data?: unknown;
   traceId?: string;


### PR DESCRIPTION
## Summary
- 引入 SuperflowDB，实现运行数据及日志的 Dexie 同步持久化
- 新增 runId/chainId 生成逻辑与 NDJSON 日志导出
- 测试环境接入 fake-indexeddb 以支持 Dexie

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b933b97bf0832a8f725210310a3b42