### PR TITLE
feat: 新增 workflow 嵌入元素与跨域消息协议

### DIFF
--- a/embeds/workflow-flow.ts
+++ b/embeds/workflow-flow.ts
@@ -1,0 +1,22 @@
+import WorkflowNodeElement from './workflow-node';
+
+/**
+ * `<workflow-flow>` 自定义元素，用于在宿主页面中嵌入完整流程。
+ * 继承自 `<workflow-node>`，沿用相同的 postMessage 协议。
+ */
+class WorkflowFlowElement extends WorkflowNodeElement {
+  /**
+   * 对外广播流程运行的引用 ID。
+   */
+  public notifyRun(id: string): void {
+    this.notifyRef(id);
+  }
+
+  protected override provideDetail(_id: string): unknown {
+    return undefined;
+  }
+}
+
+customElements.define('workflow-flow', WorkflowFlowElement);
+
+export default WorkflowFlowElement;

--- a/embeds/workflow-node.ts
+++ b/embeds/workflow-node.ts
@@ -1,0 +1,87 @@
+interface WorkflowMessage {
+  type: string;
+  [key: string]: unknown;
+}
+
+/**
+ * `<workflow-node>` 自定义元素，用于在宿主页面中嵌入单个节点。
+ * 通过 postMessage 与宿主通信，默认只传递引用 ID。
+ */
+class WorkflowNodeElement extends HTMLElement {
+  private readonly allowedOrigins: Set<string>;
+
+  private readonly token: string;
+
+  private readonly verifiedOrigins = new Set<string>();
+
+  constructor() {
+    super();
+    const originsAttr = this.getAttribute('allowed-origins') ?? '';
+    this.allowedOrigins = new Set(
+      originsAttr
+        .split(',')
+        .map((o) => o.trim())
+        .filter(Boolean)
+    );
+    this.token = this.getAttribute('token') ?? '';
+    this.handleMessage = this.handleMessage.bind(this);
+  }
+
+  connectedCallback(): void {
+    window.addEventListener('message', this.handleMessage);
+  }
+
+  disconnectedCallback(): void {
+    window.removeEventListener('message', this.handleMessage);
+  }
+
+  private handleMessage(event: MessageEvent<WorkflowMessage>): void {
+    if (!this.allowedOrigins.has(event.origin)) return;
+    const { data } = event;
+    if (typeof data !== 'object' || data === null) return;
+
+    switch (data.type) {
+      case 'handshake':
+        if (data.token === this.token) {
+          this.verifiedOrigins.add(event.origin);
+          window.postMessage({ type: 'handshake:ack' }, event.origin);
+        }
+        break;
+      case 'request-detail':
+        if (
+          this.verifiedOrigins.has(event.origin) &&
+          typeof data.id === 'string'
+        ) {
+          const detail = this.provideDetail(data.id);
+          window.postMessage(
+            { type: 'detail', id: data.id, detail },
+            event.origin
+          );
+        }
+        break;
+      default:
+        break;
+    }
+  }
+
+  /**
+   * 对外发送引用 ID，默认不包含正文数据。
+   */
+  public notifyRef(id: string): void {
+    this.verifiedOrigins.forEach((origin) => {
+      window.postMessage({ type: 'ref', id }, origin);
+    });
+  }
+
+  /**
+   * 宿主二次授权后返回详细数据，默认实现返回 undefined。
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  protected provideDetail(_id: string): unknown {
+    return undefined;
+  }
+}
+
+customElements.define('workflow-node', WorkflowNodeElement);
+
+export default WorkflowNodeElement;


### PR DESCRIPTION
## Summary
- 定义 `<workflow-node>` 与 `<workflow-flow>` 自定义元素
- 设计基于 origin 白名单与 token 的 postMessage 握手
- 默认跨域仅发送引用 ID，宿主二次授权后才返回详细数据

## Testing
- `npm run lint`
- `npm test`
- `npm run type-check`
- `npm run format:check`


------
https://chatgpt.com/codex/tasks/task_b_68b933c95eb8832aa6b59e81d3010b91