### PR TITLE
feat: 定义执行协议并实现运行时客户端与执行器

### DIFF
--- a/packages/@core/observability/src/logger.ts
+++ b/packages/@core/observability/src/logger.ts
@@ -1,0 +1,18 @@
+import type { LogLevel } from '../protocol/src';
+
+export interface LogRow {
+  ts: number;
+  level: LogLevel;
+  nodeId?: string | undefined;
+  runId?: string | undefined;
+  chainId?: string | undefined;
+  fields?: Record<string, unknown> | undefined;
+}
+
+export interface Logger {
+  log(row: LogRow): void;
+}
+
+export function createLogRow(row: LogRow): LogRow {
+  return row;
+}

--- a/packages/@core/observability/src/trace.ts
+++ b/packages/@core/observability/src/trace.ts
@@ -1,0 +1,10 @@
+export interface Trace {
+  chainId: string;
+  runId: string;
+  parentId?: string | undefined;
+  nodeId?: string | undefined;
+}
+
+export function createTrace(trace: Trace): Trace {
+  return trace;
+}

--- a/packages/@core/protocol/src/index.ts
+++ b/packages/@core/protocol/src/index.ts
@@ -1,0 +1,15 @@
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+export interface ExecRequest {
+  /** 用于匹配返回事件的 id */
+  id: string;
+  /** 指向 capabilities.ts 中的白名单键 */
+  capability: string;
+  /** 传入远程函数的参数 */
+  args?: unknown[];
+}
+
+export type ExecEvent =
+  | { type: 'log'; level: LogLevel; message: string }
+  | { type: 'result'; value: unknown }
+  | { type: 'error'; error: unknown };

--- a/packages/@core/runtime/runnerClient.ts
+++ b/packages/@core/runtime/runnerClient.ts
@@ -1,0 +1,16 @@
+import * as Comlink from 'comlink';
+import type { ExecRequest, ExecEvent } from '../protocol/src';
+
+/**
+ * 创建运行时客户端，通过 MessageChannel 将端口传递给 worker。
+ */
+export function createRunnerClient(worker: Worker) {
+  const channel = new MessageChannel();
+  worker.postMessage({ port: channel.port1 }, [channel.port1]);
+  const remote = Comlink.wrap<{ exec(req: ExecRequest): Promise<ExecEvent> }>(
+    channel.port2,
+  );
+  return {
+    exec: (req: ExecRequest) => remote.exec(req),
+  };
+}

--- a/packages/@workers/executor/src/capabilities.ts
+++ b/packages/@workers/executor/src/capabilities.ts
@@ -1,0 +1,7 @@
+export type Capability = (...args: unknown[]) => unknown | Promise<unknown>;
+
+/**
+ * 允许远程调用的函数白名单。
+ * 默认情况下为空，任何未列出的 capability 都会被拒绝。
+ */
+export const capabilities: Record<string, Capability> = {};

--- a/packages/@workers/executor/src/worker.ts
+++ b/packages/@workers/executor/src/worker.ts
@@ -1,0 +1,18 @@
+import * as Comlink from 'comlink';
+import { capabilities } from './capabilities';
+import type { ExecRequest, ExecEvent } from '../../../@core/protocol/src';
+
+async function exec(request: ExecRequest): Promise<ExecEvent> {
+  const fn = capabilities[request.capability];
+  if (!fn) {
+    return { type: 'error', error: new Error('capability not allowed') };
+  }
+  try {
+    const value = await fn(...(request.args ?? []));
+    return { type: 'result', value };
+  } catch (error) {
+    return { type: 'error', error };
+  }
+}
+
+Comlink.expose({ exec });


### PR DESCRIPTION
## Summary
- 定义 `ExecRequest`、`ExecEvent`、`LogLevel` 等协议类型
- 增加 `createRunnerClient` 组装消息通道
- 实现执行器 `worker` 并通过 `capabilities` 白名单开放能力

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b933eb9b68832a98b65f01ca29e788