### PR TITLE
Merge: integration of codex/ci-dep-boundaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,10 @@ jobs:
       - name: Check formatting
         run: npm run format:check
 
+      - name: Dependency boundaries (depcruiser)
+        run: npm run depcruise:ci
+        continue-on-error: false
+
   # 多版本矩阵测试
   test:
     name: Test (Node ${{ matrix.node-version }})

--- a/configs/depcruiser/.dependency-cruiser.cjs
+++ b/configs/depcruiser/.dependency-cruiser.cjs
@@ -1,0 +1,38 @@
+/** @type {import('dependency-cruiser').IConfiguration} */
+module.exports = {
+  options: {
+    tsConfig: { fileName: 'tsconfig.json' },
+    doNotFollow: { path: ['node_modules'] },
+    includeOnly: ['^src', '^packages'],
+    reporterOptions: { dot: { theme: 'default' } },
+  },
+  forbidden: [
+    // 基础：禁止循环依赖
+    { name: 'no-cycles', severity: 'error', from: {}, to: { circular: true } },
+
+    // 分层：core 不得依赖 app 或 src
+    {
+      name: 'core-no-upward',
+      severity: 'error',
+      from: { path: '^packages/@core' },
+      to: { path: '^(packages/@app|src)/' },
+    },
+
+    // 分层：data 不得依赖 app 或 src
+    {
+      name: 'data-no-upward',
+      severity: 'error',
+      from: { path: '^packages/@data' },
+      to: { path: '^(packages/@app|src)/' },
+    },
+
+    // 分层：packages 代码不得反向依赖 src（应用层）
+    {
+      name: 'packages-no-depend-on-src',
+      severity: 'error',
+      from: { path: '^packages/' },
+      to: { path: '^src/' },
+    },
+  ],
+};
+

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -78,6 +78,20 @@ export default [
       'prefer-const': 'error',
       '@typescript-eslint/no-non-null-assertion': 'warn',
       'no-console': 'error',
+      // packages 层禁止直接依赖应用层 alias '@/..'
+      'no-restricted-imports': [
+        'warn',
+        {
+          patterns: [
+            {
+              group: ['@/*'],
+              message:
+                "Packages 代码不得依赖 src ('@/...')，请通过 @core/@data 等包暴露的 API",
+              caseSensitive: false,
+            },
+          ],
+        },
+      ],
     },
   },
 ];

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "test:e2e": "vitest --config vitest.e2e.config.ts",
     "test:module": "vitest --run src/",
     "lint": "eslint .",
+    "depcruise": "depcruise --ts-config tsconfig.json --config configs/depcruiser/.dependency-cruiser.cjs --include-only '^(src|packages)' src packages",
+    "depcruise:ci": "depcruise --ts-config tsconfig.json --config configs/depcruiser/.dependency-cruiser.cjs --include-only '^(src|packages)' --output-type err html:dist/depcruise.html src packages",
     "lint:fix": "eslint . --fix",
     "type-check": "tsc --noEmit",
     "format": "prettier --write .",
@@ -54,7 +56,8 @@
     "typescript": "^5.4.2",
     "vite": "^5.1.6",
     "vitest": "^3.2.4",
-    "wait-on": "^8.0.4"
+    "wait-on": "^8.0.4",
+    "dependency-cruiser": "^16.6.1"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/packages/@app/services/src/RunCenterService.ts
+++ b/packages/@app/services/src/RunCenterService.ts
@@ -3,7 +3,7 @@
  * 运行中心服务类，处理流程执行和监控
  */
 
-import { generateId } from '@/shared/utils';
+import { ulid as generateId } from 'ulid';
 import { SuperflowDB } from '@data';
 import type { RunRecord, RunLog, RunStatus } from '@core/run';
 


### PR DESCRIPTION
This PR integrates local branch codex/ci-dep-boundaries (CI fixes + depcruiser config + minor ESLint/CI tweaks).\n\nGoal: unblock CI and provide a baseline for merging additional codex/* branches.\n\n- Fix package.json malformed devDependencies leftover line\n- Add configs/depcruiser/.dependency-cruiser.cjs for CI dep boundaries\n- Minor ESLint and CI workflow improvements\n\nAfter merge, we can incrementally merge remaining origin/codex/* branches.