### PR TITLE
chore: 添加文档构建与渲染测试

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,9 @@ jobs:
             npm install
           fi
 
+      - name: Build docs
+        run: npm run docs:build
+
       - name: Run unit tests
         run: npm run test
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc --project tsconfig.build.json && vite build",
+    "docs:build": "node scripts/build-docs.mjs",
     "test": "vitest run",
     "test:watch": "vitest --watch",
     "test:coverage": "node scripts/test-coverage.mjs",

--- a/scripts/build-docs.mjs
+++ b/scripts/build-docs.mjs
@@ -1,0 +1,9 @@
+import { cpSync, rmSync } from 'fs';
+import { join } from 'path';
+
+const source = join(process.cwd(), 'docs');
+const dest = join(process.cwd(), 'dist', 'docs');
+
+rmSync(dest, { recursive: true, force: true });
+cpSync(source, dest, { recursive: true });
+console.log('文档已构建到', dest);

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import App from '../App';
+
+describe('App', () => {
+  it('页面能够渲染', () => {
+    render(<App />);
+    expect(screen.getByText('工作流编排 Studio').outerHTML).toMatchSnapshot();
+  });
+});

--- a/src/__tests__/__snapshots__/App.test.tsx.snap
+++ b/src/__tests__/__snapshots__/App.test.tsx.snap
@@ -1,0 +1,3 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`App > 页面能够渲染 1`] = `"<span class="text-xl font-semibold">工作流编排 Studio</span>"`;


### PR DESCRIPTION
## Summary
- 增加 `docs:build` 构建脚本并在 CI 中执行
- 编写 `App` 渲染快照测试确保页面可加载

## Testing
- `npm run docs:build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68bd255e9668832aaedfbcd68fdc3980