### PR TITLE
feat: 使用设计系统组件

### DIFF
--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,6 +1,26 @@
 import React from 'react';
-export const Badge: React.FC<React.PropsWithChildren<{ variant?: string; className?: string }>> = ({ children, className }) => (
-  <span className={className} style={{ padding: '2px 6px', border: '1px solid #e5e7eb', borderRadius: 999 }}>{children}</span>
-);
-export default Badge;
 
+export interface BadgeProps {
+  className?: string;
+  variant?: 'default' | 'secondary';
+}
+
+export const Badge: React.FC<React.PropsWithChildren<BadgeProps>> = ({
+  children,
+  className = '',
+  variant = 'default',
+}) => {
+  const variantClasses: Record<string, string> = {
+    default: 'border border-gray-200 bg-white text-gray-700',
+    secondary: 'border border-gray-200 bg-gray-100 text-gray-700',
+  };
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs ${variantClasses[variant]} ${className}`}
+    >
+      {children}
+    </span>
+  );
+};
+
+export default Badge;

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,6 +1,38 @@
 import React from 'react';
-export const Button: React.FC<React.ButtonHTMLAttributes<HTMLButtonElement>> = ({ children, ...rest }) => (
-  <button {...rest}>{children}</button>
-);
-export default Button;
 
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'default' | 'outline' | 'ghost' | 'link' | 'secondary';
+  size?: 'sm' | 'md' | 'lg';
+}
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  (
+    { className = '', variant = 'default', size = 'md', children, ...rest },
+    ref
+  ) => {
+    const variantClasses: Record<string, string> = {
+      default: 'border border-gray-300 bg-white hover:bg-gray-50',
+      outline: 'border border-gray-300 bg-transparent hover:bg-gray-50',
+      ghost: 'border-0 bg-transparent hover:bg-gray-100',
+      link: 'border-0 bg-transparent underline text-blue-600 px-0 py-0',
+      secondary: 'border border-gray-300 bg-gray-100 hover:bg-gray-200',
+    };
+    const sizeClasses: Record<string, string> = {
+      sm: 'px-2 py-1 text-xs',
+      md: 'px-3 py-1.5 text-sm',
+      lg: 'px-4 py-2 text-base',
+    };
+    return (
+      <button
+        ref={ref}
+        className={`inline-flex items-center justify-center rounded-md disabled:opacity-50 ${variantClasses[variant]} ${sizeClasses[size]} ${className}`}
+        {...rest}
+      >
+        {children}
+      </button>
+    );
+  }
+);
+Button.displayName = 'Button';
+export default Button;

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,15 +1,48 @@
 import React from 'react';
+
 type BoxProps = { className?: string; style?: React.CSSProperties };
-export const Card: React.FC<React.PropsWithChildren<BoxProps>> = ({ className, style, children }) => (
-  <div className={className} style={{ border: '1px solid #e5e7eb', borderRadius: 8, ...(style || {}) }}>{children}</div>
+
+export const Card: React.FC<React.PropsWithChildren<BoxProps>> = ({
+  className = '',
+  style,
+  children,
+}) => (
+  <div
+    className={`rounded-md border border-gray-200 bg-white ${className}`}
+    style={style}
+  >
+    {children}
+  </div>
 );
-export const CardHeader: React.FC<React.PropsWithChildren<BoxProps>> = ({ className, style, children }) => (
-  <div className={className} style={{ padding: 8, ...(style || {}) }}>{children}</div>
+
+export const CardHeader: React.FC<React.PropsWithChildren<BoxProps>> = ({
+  className = '',
+  style,
+  children,
+}) => (
+  <div className={`p-2 ${className}`} style={style}>
+    {children}
+  </div>
 );
-export const CardContent: React.FC<React.PropsWithChildren<BoxProps>> = ({ className, style, children }) => (
-  <div className={className} style={{ padding: 8, ...(style || {}) }}>{children}</div>
+
+export const CardContent: React.FC<React.PropsWithChildren<BoxProps>> = ({
+  className = '',
+  style,
+  children,
+}) => (
+  <div className={`p-2 ${className}`} style={style}>
+    {children}
+  </div>
 );
-export const CardTitle: React.FC<React.PropsWithChildren<BoxProps>> = ({ className, style, children }) => (
-  <div className={className} style={{ fontWeight: 600, ...(style || {}) }}>{children}</div>
+
+export const CardTitle: React.FC<React.PropsWithChildren<BoxProps>> = ({
+  className = '',
+  style,
+  children,
+}) => (
+  <div className={`font-semibold ${className}`} style={style}>
+    {children}
+  </div>
 );
+
 export default { Card, CardHeader, CardContent, CardTitle };

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,7 +1,14 @@
 import React from 'react';
-export const Input = React.forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLInputElement>>((props, ref) => (
-  <input ref={ref} {...props} />
+
+export const Input = React.forwardRef<
+  HTMLInputElement,
+  React.InputHTMLAttributes<HTMLInputElement>
+>(({ className = '', ...props }, ref) => (
+  <input
+    ref={ref}
+    className={`flex h-9 w-full rounded-md border border-gray-300 bg-white px-3 py-1 text-sm placeholder:text-gray-400 focus:outline-none focus:ring-1 focus:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-50 ${className}`}
+    {...props}
+  />
 ));
 Input.displayName = 'Input';
 export default Input;
-

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
-export const ScrollArea: React.FC<React.PropsWithChildren<{ className?: string }>> = ({ className, children }) => (
-  <div className={className} style={{ overflow: 'auto' }}>
-    {children}
-  </div>
-);
-export default ScrollArea;
 
+export const ScrollArea: React.FC<
+  React.PropsWithChildren<{ className?: string }>
+> = ({ className = '', children }) => (
+  <div className={`overflow-auto ${className}`}>{children}</div>
+);
+
+export default ScrollArea;

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -9,7 +9,12 @@ interface Ctx {
 
 const SelectCtx = createContext<Ctx | null>(null);
 
-export const Select: React.FC<React.PropsWithChildren<{ value?: string; onValueChange?: (v: string) => void }>> = ({ value, onValueChange, children }) => {
+export const Select: React.FC<
+  React.PropsWithChildren<{
+    value?: string;
+    onValueChange?: (v: string) => void;
+  }>
+> = ({ value, onValueChange, children }) => {
   const [val, setVal] = useState<string | undefined>(value);
   const [open, setOpen] = useState(false);
   const setValue = (v: string) => {
@@ -17,37 +22,80 @@ export const Select: React.FC<React.PropsWithChildren<{ value?: string; onValueC
     onValueChange?.(v);
     setOpen(false);
   };
-  return <SelectCtx.Provider value={{ value: val, setValue, open, setOpen }}>{children}</SelectCtx.Provider>;
+  return (
+    <SelectCtx.Provider value={{ value: val, setValue, open, setOpen }}>
+      {children}
+    </SelectCtx.Provider>
+  );
 };
 
-export const SelectTrigger: React.FC<React.PropsWithChildren<{ className?: string }>> = ({ children, className }) => {
+export const SelectTrigger: React.FC<
+  React.ButtonHTMLAttributes<HTMLButtonElement>
+> = ({ children, className = '', ...props }) => {
   const ctx = useContext(SelectCtx)!;
   return (
-    <button className={className} onClick={() => ctx.setOpen(!ctx.open)}>
+    <button
+      className={`inline-flex items-center justify-between px-3 py-1.5 text-sm border border-gray-300 rounded-md bg-white hover:bg-gray-50 ${className}`}
+      onClick={() => ctx.setOpen(!ctx.open)}
+      {...props}
+    >
       {children}
     </button>
   );
 };
 
-export const SelectContent: React.FC<React.PropsWithChildren> = ({ children }) => {
+export const SelectContent: React.FC<React.PropsWithChildren> = ({
+  children,
+}) => {
   const ctx = useContext(SelectCtx)!;
   if (!ctx.open) return null;
-  return <div style={{ border: '1px solid #e5e7eb', background: '#fff' }}>{children}</div>;
-};
-
-export const SelectItem: React.FC<React.PropsWithChildren<{ value: string }>> = ({ value, children }) => {
-  const ctx = useContext(SelectCtx)!;
   return (
-    <div style={{ padding: 4, cursor: 'pointer' }} onClick={() => ctx.setValue(value)}>
+    <div className="mt-1 rounded-md border border-gray-200 bg-white shadow-sm">
       {children}
     </div>
   );
 };
 
-export const SelectValue: React.FC<{ placeholder?: string }> = ({ placeholder }) => {
+export const SelectItem: React.FC<
+  React.PropsWithChildren<{ value: string }>
+> = ({ value, children }) => {
+  const ctx = useContext(SelectCtx)!;
+  return (
+    <div
+      className="cursor-pointer px-2 py-1 text-sm hover:bg-gray-100"
+      onClick={() => ctx.setValue(value)}
+    >
+      {children}
+    </div>
+  );
+};
+
+export const SelectValue: React.FC<{ placeholder?: string }> = ({
+  placeholder,
+}) => {
   const ctx = useContext(SelectCtx)!;
   return <span>{ctx.value ?? placeholder ?? '请选择'}</span>;
 };
 
-export default { Select, SelectTrigger, SelectContent, SelectItem, SelectValue };
+export const NativeSelect = React.forwardRef<
+  HTMLSelectElement,
+  React.SelectHTMLAttributes<HTMLSelectElement>
+>(({ className = '', children, ...props }, ref) => (
+  <select
+    ref={ref}
+    className={`px-3 py-1.5 text-sm border border-gray-300 rounded-md bg-white ${className}`}
+    {...props}
+  >
+    {children}
+  </select>
+));
+NativeSelect.displayName = 'NativeSelect';
 
+export default {
+  Select,
+  SelectTrigger,
+  SelectContent,
+  SelectItem,
+  SelectValue,
+  NativeSelect,
+};

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -6,7 +6,9 @@ interface TabsCtx {
 }
 const Ctx = createContext<TabsCtx | null>(null);
 
-export const Tabs: React.FC<React.PropsWithChildren<{ defaultValue: string; className?: string }>> = ({ defaultValue, children, className }) => {
+export const Tabs: React.FC<
+  React.PropsWithChildren<{ defaultValue: string; className?: string }>
+> = ({ defaultValue, children, className }) => {
   const [value, setValue] = useState(defaultValue);
   return (
     <Ctx.Provider value={{ value, setValue }}>
@@ -15,23 +17,31 @@ export const Tabs: React.FC<React.PropsWithChildren<{ defaultValue: string; clas
   );
 };
 
-export const TabsList: React.FC<React.PropsWithChildren> = ({ children }) => <div>{children}</div>;
+export const TabsList: React.FC<React.PropsWithChildren> = ({ children }) => (
+  <div>{children}</div>
+);
 
-export const TabsTrigger: React.FC<React.PropsWithChildren<{ value: string }>> = ({ value, children }) => {
+export const TabsTrigger: React.FC<
+  React.PropsWithChildren<{ value: string; className?: string }>
+> = ({ value, className = '', children }) => {
   const ctx = useContext(Ctx)!;
   const active = ctx.value === value;
   return (
-    <button onClick={() => ctx.setValue(value)} style={{ fontWeight: active ? 600 : 400 }}>
+    <button
+      onClick={() => ctx.setValue(value)}
+      className={`px-3 py-1 text-sm ${active ? 'font-semibold' : 'font-normal'} ${className}`}
+    >
       {children}
     </button>
   );
 };
 
-export const TabsContent: React.FC<React.PropsWithChildren<{ value: string; className?: string }>> = ({ value, children, className }) => {
+export const TabsContent: React.FC<
+  React.PropsWithChildren<{ value: string; className?: string }>
+> = ({ value, children, className }) => {
   const ctx = useContext(Ctx)!;
   if (ctx.value !== value) return null;
   return <div className={className}>{children}</div>;
 };
 
 export default { Tabs, TabsList, TabsTrigger, TabsContent };
-

--- a/src/run-center/RunCenterPage.tsx
+++ b/src/run-center/RunCenterPage.tsx
@@ -1,4 +1,7 @@
 import React, { useState, useMemo, useCallback } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { NativeSelect } from '@/components/ui/select';
 
 export interface NodeLog {
   id: string;
@@ -65,8 +68,8 @@ export const RunCenterPage: React.FC<RunCenterPageProps> = ({
           data-testid="global-progress"
         />
       </div>
-      <div>
-        <input
+      <div className="flex items-center gap-2 py-2">
+        <Input
           placeholder="搜索日志"
           aria-label="search"
           value={search}
@@ -74,20 +77,22 @@ export const RunCenterPage: React.FC<RunCenterPageProps> = ({
             setSearch(e.target.value);
             setPage(1);
           }}
+          className="w-48"
         />
-        <select
+        <NativeSelect
           aria-label="filter"
           value={filter}
           onChange={(e) => {
             setFilter(e.target.value as any);
             setPage(1);
           }}
+          className="w-32"
         >
           <option value="all">全部</option>
           <option value="success">成功</option>
           <option value="running">运行中</option>
           <option value="failed">失败</option>
-        </select>
+        </NativeSelect>
       </div>
       <ul>
         {pageLogs.map((log) => (
@@ -97,46 +102,49 @@ export const RunCenterPage: React.FC<RunCenterPageProps> = ({
             data-testid="log-item"
           >
             <span>
-              [{log.runId ?? ''} {log.traceId ?? ''}] 
-              <button
-                style={{ textDecoration: 'underline', cursor: 'pointer' }}
+              [{log.runId ?? ''} {log.traceId ?? ''}]
+              <Button
+                className="border-0 bg-transparent p-0 h-auto underline text-blue-600"
                 onClick={() => onFocusNode?.(log.node)}
                 aria-label={`focus-${log.node}`}
               >
                 {log.node}
-              </button>
+              </Button>
               : {log.message}
             </span>
             {log.status === 'failed' && log.error && (
               <pre data-testid="error-detail">{log.error}</pre>
             )}
-            <button onClick={() => handleRetry(log.id)}>重新运行</button>
-            <button
+            <Button onClick={() => handleRetry(log.id)} className="ml-2">
+              重新运行
+            </Button>
+            <Button
               onClick={() => log.runId && onDownload?.(log.runId)}
               disabled={!log.runId}
               data-testid="download-log"
+              className="ml-2"
             >
               下载
-            </button>
+            </Button>
           </li>
         ))}
       </ul>
-      <div>
-        <button
+      <div className="flex items-center gap-2 py-2">
+        <Button
           onClick={() => setPage((p) => Math.max(1, p - 1))}
           disabled={page === 1}
         >
           上一页
-        </button>
+        </Button>
         <span>
           {page}/{totalPages}
         </span>
-        <button
+        <Button
           onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
           disabled={page === totalPages}
         >
           下一页
-        </button>
+        </Button>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- 统一按钮、输入框等样式，移除内联样式
- RunCenterPage 使用设计系统组件

## Testing
- `npm run type-check` (fails: Type 'undefined' cannot be used as an index type)
- `npm run lint` (fails: 3 errors, 315 warnings)
- `npm run format:check` (fails: docs/工作流编排_studio（模拟页面）.jsx SyntaxError)
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68bd255be0b0832abe62b6f09a58410a