### PR TITLE
feat: 抽离状态徽章组件并补充测试

### DIFF
--- a/src/studio/StudioPage.tsx
+++ b/src/studio/StudioPage.tsx
@@ -37,6 +37,8 @@ import {
   SelectItem,
   SelectValue,
 } from '@/components/ui/select';
+import { StatusBadge, STATUS_THEME } from '@/studio/components/StatusBadge';
+import type { Status } from '@/studio/components/StatusBadge';
 import {
   Check,
   X,
@@ -63,36 +65,6 @@ import {
 } from 'lucide-react';
 
 // ---- 模拟数据结构 ----
-
-type Status =
-  | 'queued'
-  | 'running'
-  | 'success'
-  | 'failed'
-  | 'skipped'
-  | 'cached';
-
-const STATUS_THEME: Record<Status, { bg: string; dot: string; text: string }> =
-  {
-    queued: { bg: 'bg-slate-100', dot: 'bg-slate-400', text: 'text-slate-700' },
-    running: { bg: 'bg-blue-100', dot: 'bg-blue-500', text: 'text-blue-700' },
-    success: {
-      bg: 'bg-emerald-100',
-      dot: 'bg-emerald-500',
-      text: 'text-emerald-700',
-    },
-    failed: { bg: 'bg-rose-100', dot: 'bg-rose-500', text: 'text-rose-700' },
-    skipped: {
-      bg: 'bg-amber-100',
-      dot: 'bg-amber-500',
-      text: 'text-amber-700',
-    },
-    cached: {
-      bg: 'bg-violet-100',
-      dot: 'bg-violet-500',
-      text: 'text-violet-700',
-    },
-  };
 
 interface NodeMeta {
   status: Status;
@@ -288,24 +260,12 @@ const initialArtifacts: Record<string, Artifact[]> = {
 };
 
 // ---- 辅助方法 ----
-function statusBadge(s: Status) {
-  const theme = STATUS_THEME[s];
-  return (
-    <span
-      className={`inline-flex items-center gap-2 px-2 py-1 rounded-full ${theme.bg} ${theme.text}`}
-    >
-      <span className={`h-2 w-2 rounded-full ${theme.dot}`} />
-      {s}
-    </span>
-  );
-}
-
 function nodeLabel(id: string, meta: NodeMeta) {
   return (
     <div className="flex items-center gap-2">
       <Boxes className="h-4 w-4" />
       <span className="font-medium">{id}</span>
-      {statusBadge(meta.status)}
+      <StatusBadge status={meta.status} />
     </div>
   );
 }
@@ -819,7 +779,7 @@ export default function StudioPage() {
                         <Badge variant="outline" className="rounded-full">
                           {selCode.lang}
                         </Badge>
-                        {statusBadge(selMeta.status)}
+                        <StatusBadge status={selMeta.status} />
                       </div>
                     </div>
                   </CardHeader>

--- a/src/studio/components/StatusBadge.tsx
+++ b/src/studio/components/StatusBadge.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+
+export type Status =
+  | 'queued'
+  | 'running'
+  | 'success'
+  | 'failed'
+  | 'skipped'
+  | 'cached';
+
+export const STATUS_THEME: Record<
+  Status,
+  { bg: string; dot: string; text: string }
+> = {
+  queued: { bg: 'bg-slate-100', dot: 'bg-slate-400', text: 'text-slate-700' },
+  running: { bg: 'bg-blue-100', dot: 'bg-blue-500', text: 'text-blue-700' },
+  success: {
+    bg: 'bg-emerald-100',
+    dot: 'bg-emerald-500',
+    text: 'text-emerald-700',
+  },
+  failed: { bg: 'bg-rose-100', dot: 'bg-rose-500', text: 'text-rose-700' },
+  skipped: {
+    bg: 'bg-amber-100',
+    dot: 'bg-amber-500',
+    text: 'text-amber-700',
+  },
+  cached: { bg: 'bg-violet-100', dot: 'bg-violet-500', text: 'text-violet-700' },
+};
+
+interface StatusBadgeProps {
+  status: Status;
+}
+
+export const StatusBadge: React.FC<StatusBadgeProps> = ({ status }) => {
+  const theme = STATUS_THEME[status];
+  return (
+    <span
+      className={`inline-flex items-center gap-2 px-2 py-1 rounded-full ${theme.bg} ${theme.text}`}
+    >
+      <span className={`h-2 w-2 rounded-full ${theme.dot}`} />
+      {status}
+    </span>
+  );
+};
+
+export default StatusBadge;
+

--- a/src/studio/components/__tests__/StatusBadge.test.tsx
+++ b/src/studio/components/__tests__/StatusBadge.test.tsx
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import {
+  StatusBadge,
+  STATUS_THEME,
+  type Status,
+} from '@/studio/components/StatusBadge';
+
+describe('StatusBadge', () => {
+  (Object.keys(STATUS_THEME) as Status[]).forEach((status) => {
+    it(`${status} 状态渲染类名正确`, () => {
+      const { getByText } = render(<StatusBadge status={status} />);
+      const wrapper = getByText(status) as HTMLElement;
+      expect(wrapper.className).toContain(STATUS_THEME[status].bg);
+      expect(wrapper.className).toContain(STATUS_THEME[status].text);
+      const dot = wrapper.querySelector('span');
+      expect(dot?.className).toContain(STATUS_THEME[status].dot);
+    });
+  });
+});
+


### PR DESCRIPTION
## Summary
- 新增 `StatusBadge` 组件并集中定义 `STATUS_THEME`
- StudioPage 替换为 `<StatusBadge>` 渲染状态
- 补充单元测试覆盖不同状态的样式

## Testing
- `npm run type-check`
- `npm run lint`
- `npm run format:check` (fails: Code style issues found in 43 files)
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68bd2971cfc8832a82a7047b3af410c6