### PR TITLE
feat: 为测试面板添加重新运行按钮

### DIFF
--- a/src/studio/StudioPage.tsx
+++ b/src/studio/StudioPage.tsx
@@ -60,6 +60,7 @@ import {
   Download,
   ChevronLeft,
   ChevronRight,
+  Loader2,
 } from 'lucide-react';
 
 // ---- 模拟数据结构 ----
@@ -490,6 +491,15 @@ export default function StudioPage() {
   });
 
   const [tests, setTests] = useState<TestResult[]>([]);
+  const [testsRunning, setTestsRunning] = useState(false);
+
+  const handleRunTests = () => {
+    if (testsRunning) return;
+    setTestsRunning(true);
+    const res = runUnitTests();
+    setTests(res);
+    setTestsRunning(false);
+  };
 
   // 图节点着色
   const rfNodes = useMemo<Node[]>(() => {
@@ -1315,9 +1325,14 @@ export default function StudioPage() {
                           <Button
                             size="sm"
                             variant="outline"
-                            onClick={() => setTests(runUnitTests())}
+                            onClick={handleRunTests}
+                            disabled={testsRunning}
+                            className="flex items-center gap-1"
                           >
-                            重新运行
+                            {testsRunning && (
+                              <Loader2 className="h-3 w-3 animate-spin" />
+                            )}
+                            {testsRunning ? '运行中...' : '重新运行'}
                           </Button>
                         </div>
                         <div className="border rounded-xl overflow-hidden">


### PR DESCRIPTION
## Summary
- 添加单元测试“重新运行”按钮，支持加载状态并防止重复触发

## Testing
- `npm run type-check`
- `npm run lint`
- `npm run format:check` *(失败：Code style issues found in 41 files)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68bd296e2bcc832a9d61ed1059d93f62