### PR TITLE
feat: redesign chat task sidebar

### DIFF
--- a/apps/server/static/chat/index.js
+++ b/apps/server/static/chat/index.js
@@ -1,0 +1,318 @@
+import { setupWorkspaceDrawer } from './workspace.js';
+import { setupToolsPanel } from './tools.js';
+import { TaskManager } from './tasks.js';
+
+const box = document.getElementById('chatBox');
+const form = document.getElementById('chatForm');
+const sessionInput = document.getElementById('chatSession');
+const hintEl = document.getElementById('chatHint');
+const spinEl = document.getElementById('chatSpin');
+const actionBox = document.getElementById('actionBox');
+
+const fmtTime = () => {
+  const d = new Date();
+  return d.toTimeString().slice(0, 5);
+};
+
+const formatHtml = (text) => {
+  if (text === undefined || text === null) return '';
+  return String(text).replace(/\n/g, '<br>');
+};
+
+function appendMessage(role, text) {
+  if (!box) return;
+  const me = role === '你' || role === 'user';
+  const wrap = document.createElement('div');
+  wrap.className = 'msg' + (me ? ' user' : '');
+  const bubble = document.createElement('div');
+  bubble.className = 'bubble';
+  const label = me ? '你' : role || '助手';
+  bubble.innerHTML = `<b>${label}</b> · <span class="meta">${fmtTime()}</span><br>${formatHtml(text)}`;
+  wrap.appendChild(bubble);
+  box.appendChild(wrap);
+  box.scrollTop = box.scrollHeight;
+}
+
+async function loadHistory() {
+  if (!sessionInput || !box) return;
+  try {
+    const resp = await fetch(`/api/chat/history?session=${encodeURIComponent(sessionInput.value)}`);
+    const data = await resp.json();
+    if (data.ok && Array.isArray(data.history)) {
+      box.innerHTML = '';
+      data.history.forEach((m) => {
+        appendMessage(m.role === 'user' ? '你' : '助手', m.content);
+      });
+    }
+  } catch (err) {
+    console.warn('load history failed', err);
+  }
+}
+
+function setHint(msg) {
+  if (hintEl) hintEl.textContent = msg || '';
+}
+
+function setSpin(on) {
+  if (spinEl) spinEl.style.display = on ? 'inline-block' : 'none';
+}
+
+function taskTitleFromArgs(args) {
+  if (!args) return '最小闭环执行';
+  return args.goal || (args.data_path ? `最小闭环 · ${args.data_path}` : '最小闭环执行');
+}
+
+async function startJob(taskManager, runArgs) {
+  if (!runArgs) return;
+  const fd = new FormData();
+  fd.append('srs_path', runArgs.srs_path || runArgs.srsPath || 'examples/srs/weekly_report.json');
+  fd.append('data_path', runArgs.data_path || runArgs.dataPath || 'examples/data/weekly.csv');
+  fd.append('out_path', runArgs.out_path || runArgs.out || 'reports/weekly_report.md');
+  fd.append('planner', runArgs.planner || 'llm');
+  fd.append('executor', runArgs.executor || 'llm');
+  fd.append('critic', runArgs.critic || 'llm');
+  fd.append('reviser', runArgs.reviser || 'llm');
+  if (runArgs.provider) fd.append('provider', runArgs.provider);
+  if (runArgs.temp_planner) fd.append('temp_planner', runArgs.temp_planner);
+  if (runArgs.temp_executor) fd.append('temp_executor', runArgs.temp_executor);
+  if (runArgs.temp_critic) fd.append('temp_critic', runArgs.temp_critic);
+  if (runArgs.temp_reviser) fd.append('temp_reviser', runArgs.temp_reviser);
+  if (runArgs.retries !== undefined) fd.append('retries', runArgs.retries);
+  if (runArgs.max_rows !== undefined) fd.append('max_rows', runArgs.max_rows);
+
+  try {
+    setHint('开始执行…');
+    setSpin(true);
+    const resp = await fetch('/api/run', { method: 'POST', body: fd });
+    const data = await resp.json();
+    if (data.ok) {
+      setHint(`已提交，job=${data.job_id || ''}`);
+      taskManager.observeJob(data.job_id, {
+        title: taskTitleFromArgs(runArgs),
+        goal: runArgs.goal,
+        args: runArgs
+      });
+    } else {
+      setHint(data.error || '提交失败');
+    }
+  } catch (err) {
+    setHint(`提交失败: ${err.message}`);
+  } finally {
+    setTimeout(() => setSpin(false), 200);
+  }
+}
+
+function renderRunAction(taskManager, resp) {
+  if (!actionBox) return;
+  actionBox.innerHTML = '';
+  if (!resp || !resp.action || resp.action.type !== 'run') return;
+  const args = resp.action.args || {};
+  const card = document.createElement('div');
+  card.className = 'card';
+  const summary = [
+    args.srs_path ? `SRS：${args.srs_path}` : '',
+    args.data_path ? `数据：${args.data_path}` : '',
+    (args.out_path || args.out) ? `输出：${args.out_path || args.out}` : ''
+  ].filter(Boolean).join('<br>');
+  card.innerHTML = `
+    <div><b>执行建议</b> — 最小闭环</div>
+    ${summary ? `<div class="hint" style="margin-top:6px">${summary}</div>` : ''}
+    <div class="hint" style="margin-top:4px">Planner/Executor：${args.planner || 'llm'} / ${args.executor || 'llm'}</div>
+    ${resp.srs_path ? `<div class="hint" style="margin-top:4px">SRS 已保存：${resp.srs_path}</div>` : ''}
+    <div style="display:flex; gap:8px; flex-wrap:wrap; margin-top:10px">
+      <button data-action="run-now">立即运行</button>
+      <button data-action="edit-run" class="btn ghost">编辑并运行</button>
+    </div>
+  `;
+  actionBox.appendChild(card);
+  const runBtn = card.querySelector('button[data-action="run-now"]');
+  const editBtn = card.querySelector('button[data-action="edit-run"]');
+  runBtn?.addEventListener('click', () => startJob(taskManager, args));
+  editBtn?.addEventListener('click', () => {
+    try {
+      localStorage.setItem('runArgs', JSON.stringify(args));
+    } catch (err) {
+      console.warn('store runArgs fail', err);
+    }
+    location.href = '/?tab=run';
+  });
+}
+
+function init() {
+  if (sessionInput && !sessionInput.value) {
+    sessionInput.value = 's-' + Math.random().toString(16).slice(2, 10);
+  }
+
+  const taskManager = new TaskManager({
+    runningList: document.getElementById('taskListRunning'),
+    approvalList: document.getElementById('taskListApproval'),
+    doneList: document.getElementById('taskListDone'),
+    runningEmpty: document.getElementById('taskEmptyRunning'),
+    approvalEmpty: document.getElementById('taskEmptyApproval'),
+    doneEmpty: document.getElementById('taskEmptyDone'),
+    detail: {
+      card: document.getElementById('taskDetailCard'),
+      body: document.getElementById('taskDetailBody'),
+      title: document.getElementById('taskDetailTitle'),
+      subtitle: document.getElementById('taskDetailSubtitle'),
+      closeBtn: document.getElementById('taskDetailClose')
+    },
+    budget: {
+      banner: document.getElementById('budgetBanner'),
+      message: document.getElementById('budgetMessage'),
+      payload: document.getElementById('budgetPayload'),
+      dismissBtn: document.getElementById('budgetDismiss')
+    },
+    onApproval: (task, payload) => openApprovalModal(task, payload),
+    onBudget: (task, info) => {
+      appendMessage('系统', `${info.message}${task ? `（任务 ${task.title || task.jobId || ''}）` : ''}`);
+    },
+    appendMessage
+  });
+  taskManager.init();
+
+  document.getElementById('refreshTasks')?.addEventListener('click', () => taskManager.reloadCompleted());
+
+  setupWorkspaceDrawer({
+    drawer: document.getElementById('wsDrawer'),
+    openButton: document.getElementById('btnWs'),
+    closeButton: document.getElementById('btnCloseWs'),
+    backdrop: document.querySelector('#wsDrawer .backdrop'),
+    treeEl: document.getElementById('wsTree'),
+    cwdEl: document.getElementById('wsCwd'),
+    previewWrap: document.getElementById('wsPreviewWrap'),
+    selectedPathEl: document.getElementById('wsSel'),
+    contentEl: document.getElementById('wsContent'),
+    hintEl: document.getElementById('wsHint'),
+    tokenInput: document.getElementById('wsToken'),
+    insertButton: document.getElementById('btnInsert'),
+    saveButton: document.getElementById('btnSave'),
+    onInsert: (path, content) => {
+      if (form && form.text) {
+        form.text.value = `请参考文件 ${path} 的内容：\n\n\u0060\u0060\u0060\n${content}\n\u0060\u0060\u0060\n`;
+        form.text.focus();
+      }
+    },
+    initialPath: 'examples'
+  });
+
+  setupToolsPanel({
+    toggleButton: document.getElementById('btnTools'),
+    panelEl: document.getElementById('toolsPanel'),
+    hintEl,
+    spinEl,
+    appendMessage
+  });
+
+  if (form) {
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const fd = new FormData(form);
+      const text = fd.get('text');
+      if (!text) return;
+      appendMessage('你', text);
+      if (form.text) form.text.value = '';
+      setHint('思考中…');
+      setSpin(true);
+      try {
+        const resp = await fetch(form.action, { method: 'POST', body: fd });
+        const data = await resp.json();
+        if (data.ok) {
+          appendMessage('助手', data.reply || '');
+        } else {
+          appendMessage('系统', data.error || '发送失败');
+        }
+        renderRunAction(taskManager, data);
+      } catch (err) {
+        appendMessage('系统', `发送失败: ${err.message}`);
+      } finally {
+        setHint('');
+        setTimeout(() => setSpin(false), 200);
+      }
+    });
+  }
+
+  loadHistory();
+
+  setupApprovalModal(taskManager, appendMessage);
+}
+
+let approvalHandler = null;
+
+function setupApprovalModal(taskManager, appendMessageFn) {
+  const modal = document.getElementById('approvalModal');
+  if (!modal) return;
+  const messageEl = document.getElementById('approvalMessage');
+  const payloadEl = document.getElementById('approvalPayload');
+  const closeBtn = document.getElementById('approvalClose');
+  const backdrop = modal.querySelector('.modal-backdrop');
+  const actionButtons = modal.querySelectorAll('.modal-actions button[data-action]');
+
+  const close = () => {
+    modal.classList.remove('open');
+    modal.removeAttribute('data-task-id');
+  };
+
+  const open = (task, payload) => {
+    modal.dataset.taskId = task.id;
+    if (messageEl) {
+      messageEl.textContent = (payload && (payload.message || payload.reason)) || '任务需要审批';
+    }
+    if (payloadEl) {
+      if (payload) {
+        payloadEl.style.display = 'block';
+        payloadEl.textContent = JSON.stringify(payload, null, 2);
+      } else {
+        payloadEl.style.display = 'none';
+        payloadEl.textContent = '';
+      }
+    }
+    modal.classList.add('open');
+  };
+
+  const submitDecision = async (decision) => {
+    const taskId = modal.dataset.taskId;
+    if (!taskId) {
+      close();
+      return;
+    }
+    const task = taskManager.getTask(taskId);
+    close();
+    if (!task) return;
+    try {
+      const payload = { decision };
+      if (task.jobId) payload.job_id = task.jobId;
+      if (task.traceId) payload.trace_id = task.traceId;
+      const resp = await fetch('/agent/approve', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      });
+      const data = await resp.json();
+      if (!data.ok) {
+        appendMessageFn('系统', `审批提交失败: ${data.error || ''}`);
+      } else {
+        appendMessageFn('系统', `审批已提交（${decision}）`);
+        taskManager.resolveApproval(task.id, decision);
+      }
+    } catch (err) {
+      appendMessageFn('系统', `审批提交失败: ${err.message}`);
+    }
+  };
+
+  actionButtons.forEach((btn) => {
+    btn.addEventListener('click', () => submitDecision(btn.getAttribute('data-action')));
+  });
+  closeBtn?.addEventListener('click', close);
+  backdrop?.addEventListener('click', close);
+
+  approvalHandler = open;
+}
+
+function openApprovalModal(task, payload) {
+  if (approvalHandler) {
+    approvalHandler(task, payload);
+  }
+}
+
+init();

--- a/apps/server/static/chat/tasks.js
+++ b/apps/server/static/chat/tasks.js
@@ -1,0 +1,649 @@
+const STAGE_ORDER = ['perceive', 'plan', 'execute', 'review', 'revise', 'record', 'deliver'];
+const STAGE_LABELS = {
+  perceive: '感知',
+  plan: '规划',
+  execute: '执行',
+  review: '评审',
+  revise: '修补',
+  record: '记账',
+  deliver: '交付'
+};
+const DONE_STATUSES = new Set(['done', 'success', 'completed', 'artifact']);
+const FAILED_STATUSES = new Set(['failed', 'error', 'stopped']);
+
+const STATUS_TEXT = {
+  running: '进行中',
+  approval: '待审批',
+  done: '已完成',
+  failed: '失败'
+};
+
+const escapeHtml = (value) => {
+  if (value === undefined || value === null) return '';
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+};
+
+const stageLabel = (id) => STAGE_LABELS[id] || id || '';
+
+const formatTimestamp = (ts) => {
+  if (!ts) return '';
+  try {
+    const d = new Date(ts);
+    if (!Number.isNaN(d.getTime())) {
+      return d.toLocaleString('zh-CN', { hour12: false });
+    }
+  } catch (err) {
+    // ignore
+  }
+  return ts;
+};
+
+export class TaskManager {
+  constructor(options) {
+    this.options = options || {};
+    this.tasks = new Map();
+    this.listEls = {
+      running: options.runningList || null,
+      approval: options.approvalList || null,
+      done: options.doneList || null
+    };
+    this.emptyEls = {
+      running: options.runningEmpty || null,
+      approval: options.approvalEmpty || null,
+      done: options.doneEmpty || null
+    };
+    this.detail = options.detail || {};
+    this.budget = options.budget || {};
+  }
+
+  init() {
+    if (this.detail && this.detail.closeBtn) {
+      this.detail.closeBtn.addEventListener('click', () => this.hideDetail());
+    }
+    if (this.budget && this.budget.dismissBtn) {
+      this.budget.dismissBtn.addEventListener('click', () => this.hideBudgetNotice());
+    }
+    this.reloadCompleted();
+  }
+
+  getTask(id) {
+    return this.tasks.get(id);
+  }
+
+  async reloadCompleted(limit = 20) {
+    try {
+      const resp = await fetch(`/api/episodes?limit=${encodeURIComponent(limit)}`);
+      const data = await resp.json();
+      if (data.ok && Array.isArray(data.items)) {
+        data.items.forEach((item) => this._upsertCompleted(item));
+        this._updateEmptyState('done');
+      }
+    } catch (err) {
+      console.warn('load episodes failed', err);
+    }
+  }
+
+  observeJob(jobId, meta = {}) {
+    if (!jobId) return null;
+    const taskId = `job-${jobId}`;
+    let task = this.tasks.get(taskId);
+    if (!task) {
+      task = {
+        id: taskId,
+        jobId,
+        status: 'running',
+        title: meta.title || meta.goal || '最小闭环执行',
+        goal: meta.goal,
+        createdAt: new Date().toISOString(),
+        progress: { stage: null, status: 'pending', message: '', percent: 0 },
+        stages: new Map(),
+        logs: [],
+        events: [],
+        meta
+      };
+      this.tasks.set(taskId, task);
+      this._ensureElement(task);
+      this._setTaskGroup(task, 'running');
+      this._updateTaskElement(task);
+      this._connect(task);
+    } else if (!task.ws) {
+      this._connect(task);
+    }
+    return task;
+  }
+
+  showDetail(taskId) {
+    const task = this.tasks.get(taskId);
+    if (!task || !this.detail || !this.detail.card || !this.detail.body) {
+      return;
+    }
+    this.detail.currentId = task.id;
+    this.detail.card.style.display = 'block';
+    if (this.detail.title) {
+      this.detail.title.textContent = task.title || (task.traceId ? `Episode ${task.traceId}` : '执行详情');
+    }
+    if (this.detail.subtitle) {
+      const info = [task.traceId ? `trace ${task.traceId}` : '', task.jobId ? `job ${task.jobId}` : '']
+        .filter(Boolean)
+        .join(' • ');
+      this.detail.subtitle.textContent = info;
+    }
+    if (task.traceId && task.status === 'done') {
+      if (task.episodeDetail && task.episodeDetailLoaded) {
+        this._renderEpisodeDetail(task);
+      } else {
+        this._fetchEpisodeDetail(task);
+      }
+    } else {
+      this._renderLiveDetail(task);
+    }
+  }
+
+  hideDetail() {
+    if (this.detail && this.detail.card) {
+      this.detail.card.style.display = 'none';
+      this.detail.currentId = null;
+    }
+  }
+
+  resolveApproval(taskId, decision) {
+    const task = this.tasks.get(taskId);
+    if (!task) return;
+    task.approvalDecision = decision;
+    if (decision === 'reject') {
+      this._markError(task, '已终止');
+    } else {
+      task.status = 'running';
+      this._setTaskGroup(task, 'running');
+      this._updateTaskElement(task);
+    }
+  }
+
+  hideBudgetNotice() {
+    if (this.budget && this.budget.banner) {
+      this.budget.banner.style.display = 'none';
+      if (this.budget.message) this.budget.message.textContent = '';
+      if (this.budget.payload) this.budget.payload.textContent = '';
+      this.budget.currentTaskId = null;
+    }
+  }
+
+  showBudgetNotice(task, info) {
+    if (!this.budget || !this.budget.banner) return;
+    const { banner, message, payload } = this.budget;
+    banner.style.display = 'block';
+    if (message) {
+      message.textContent = info.message || '预算提示';
+    }
+    if (payload) {
+      if (info.payload) {
+        payload.style.display = 'block';
+        payload.textContent = typeof info.payload === 'string'
+          ? info.payload
+          : JSON.stringify(info.payload, null, 2);
+      } else {
+        payload.style.display = 'none';
+        payload.textContent = '';
+      }
+    }
+    this.budget.currentTaskId = task ? task.id : null;
+  }
+
+  // ---- private helpers ----
+  _upsertCompleted(item) {
+    if (!item || !item.trace_id) return;
+    const id = `ep-${item.trace_id}`;
+    let task = this.tasks.get(id);
+    if (!task) {
+      task = {
+        id,
+        traceId: item.trace_id,
+        status: 'done',
+        title: item.goal || `Episode ${item.trace_id}`,
+        goal: item.goal,
+        createdAt: item.created_ts,
+        completedAt: item.created_ts,
+        statusText: item.status,
+        provider: item.provider,
+        model: item.model,
+        attempts: item.attempts,
+        cost: item.cost,
+        latency: item.latency_ms,
+        progress: { stage: 'deliver', status: 'done', percent: 100 },
+        stages: new Map(),
+        logs: [],
+        events: []
+      };
+      this.tasks.set(id, task);
+      this._ensureElement(task);
+      this._setTaskGroup(task, 'done');
+    } else {
+      task.traceId = item.trace_id;
+      task.status = 'done';
+      task.title = item.goal || task.title;
+      task.goal = item.goal || task.goal;
+      task.statusText = item.status || task.statusText;
+      task.provider = item.provider;
+      task.model = item.model;
+      task.attempts = item.attempts;
+      task.cost = item.cost;
+      task.latency = item.latency_ms;
+      task.completedAt = item.created_ts || task.completedAt;
+      this._ensureElement(task);
+      this._setTaskGroup(task, 'done');
+    }
+    this._updateTaskElement(task);
+  }
+
+  _ensureElement(task) {
+    if (task.element) {
+      task.element.dataset.taskId = task.id;
+      return task.element;
+    }
+    const el = document.createElement('div');
+    el.className = 'task-item';
+    el.dataset.taskId = task.id;
+    el.innerHTML = `
+      <div class="task-item-header">
+        <div class="task-title"></div>
+        <span class="task-badge neutral"></span>
+      </div>
+      <div class="task-meta"></div>
+      <div class="task-progress"><div class="task-progress-bar"></div></div>
+      <div class="task-extra"></div>
+    `;
+    el.addEventListener('click', () => this.showDetail(task.id));
+    task.element = el;
+    return el;
+  }
+
+  _setTaskGroup(task, group) {
+    if (!task.element) this._ensureElement(task);
+    if (task.group === group) {
+      this._updateEmptyState(group);
+      return;
+    }
+    if (task.element && task.element.parentElement) {
+      const oldParent = task.element.parentElement;
+      oldParent.removeChild(task.element);
+      const oldGroup = task.group;
+      if (oldGroup) this._updateEmptyState(oldGroup);
+    }
+    const list = this.listEls[group];
+    if (list) {
+      list.appendChild(task.element);
+    }
+    task.group = group;
+    this._updateEmptyState(group);
+  }
+
+  _updateEmptyState(group) {
+    const list = this.listEls[group];
+    const empty = this.emptyEls[group];
+    if (!empty) return;
+    const hasChild = !!(list && list.children && list.children.length);
+    empty.style.display = hasChild ? 'none' : 'block';
+  }
+
+  _calcProgressPercent(task) {
+    if (!task || !task.progress) {
+      return task && task.status === 'done' ? 100 : 0;
+    }
+    const stage = task.progress.stage;
+    const status = (task.progress.status || '').toLowerCase();
+    if (!stage) {
+      return task.status === 'done' ? 100 : 0;
+    }
+    const idx = STAGE_ORDER.indexOf(stage);
+    if (idx === -1) {
+      return task.status === 'done' ? 100 : 0;
+    }
+    const total = STAGE_ORDER.length;
+    let percent;
+    if (DONE_STATUSES.has(status) || task.status === 'done') {
+      percent = ((idx + 1) / total) * 100;
+    } else if (FAILED_STATUSES.has(status) || task.status === 'failed') {
+      percent = ((idx + 0.5) / total) * 100;
+    } else {
+      percent = ((idx + 0.5) / total) * 100;
+    }
+    if (task.status === 'done') percent = 100;
+    if (task.status === 'failed') percent = Math.min(100, Math.max(5, percent));
+    return Math.round(percent);
+  }
+
+  _updateTaskElement(task) {
+    if (!task) return;
+    const el = this._ensureElement(task);
+    const titleEl = el.querySelector('.task-title');
+    const badgeEl = el.querySelector('.task-badge');
+    const metaEl = el.querySelector('.task-meta');
+    const extraEl = el.querySelector('.task-extra');
+    const progressWrap = el.querySelector('.task-progress');
+    const barEl = el.querySelector('.task-progress-bar');
+
+    if (titleEl) {
+      titleEl.textContent = task.title || task.goal || (task.traceId ? `Episode ${task.traceId}` : '最小闭环执行');
+    }
+
+    if (badgeEl) {
+      badgeEl.classList.remove('danger', 'success', 'neutral');
+      let badgeClass = 'neutral';
+      if (task.status === 'done') badgeClass = 'success';
+      if (task.status === 'failed' || task.status === 'approval') badgeClass = 'danger';
+      badgeEl.classList.add(badgeClass);
+      badgeEl.textContent = STATUS_TEXT[task.status] || STATUS_TEXT.running;
+    }
+
+    if (metaEl) {
+      const parts = [];
+      if (task.jobId) parts.push(`job ${task.jobId}`);
+      if (task.traceId && task.status !== 'running') parts.push(task.traceId);
+      if (task.status === 'running' && task.progress && task.progress.stage) {
+        const statusText = task.progress.status ? `(${task.progress.status})` : '';
+        parts.push(`当前阶段：${stageLabel(task.progress.stage)} ${statusText}`.trim());
+      } else if (task.status === 'approval') {
+        parts.push(task.approvalMessage || '等待审批');
+      } else if (task.status === 'done') {
+        if (task.statusText) parts.push(`状态：${task.statusText}`);
+        if (task.cost !== undefined && task.cost !== null) parts.push(`成本 ${task.cost}`);
+        if (task.latency !== undefined && task.latency !== null) parts.push(`耗时 ${task.latency}ms`);
+      } else if (task.status === 'failed' && task.error) {
+        parts.push(task.error);
+      }
+      metaEl.textContent = parts.filter(Boolean).join(' • ');
+    }
+
+    if (extraEl) {
+      if (task.status === 'failed' && task.error) {
+        extraEl.textContent = `错误：${task.error}`;
+      } else if (task.progress && task.progress.message) {
+        extraEl.textContent = task.progress.message;
+      } else if (task.approvalMessage && task.status === 'approval') {
+        extraEl.textContent = task.approvalMessage;
+      } else {
+        extraEl.textContent = '';
+      }
+    }
+
+    if (progressWrap && barEl) {
+      const percent = this._calcProgressPercent(task);
+      barEl.style.width = `${percent}%`;
+      barEl.classList.toggle('error', task.status === 'failed');
+      progressWrap.style.display = task.status === 'done' && percent >= 100 ? 'none' : 'block';
+    }
+  }
+
+  _connect(task) {
+    if (!task || !task.jobId) return;
+    const proto = location.protocol === 'https:' ? 'wss' : 'ws';
+    const ws = new WebSocket(`${proto}://${location.host}/agent/events?job_id=${encodeURIComponent(task.jobId)}`);
+    task.ws = ws;
+    ws.addEventListener('message', (ev) => {
+      try {
+        const msg = JSON.parse(ev.data);
+        this._handleWsMessage(task, msg);
+      } catch (err) {
+        console.warn('ws message parse fail', err);
+      }
+    });
+    ws.addEventListener('close', () => {
+      task.ws = null;
+    });
+    ws.addEventListener('error', () => {
+      this._markError(task, '事件通道异常');
+    });
+  }
+
+  _handleWsMessage(task, msg) {
+    if (!msg) return;
+    switch (msg.type) {
+      case 'progress':
+        this._handleProgress(task, msg.data || {});
+        break;
+      case 'log':
+        this._handleLog(task, msg);
+        break;
+      case 'event':
+        this._handleEvent(task, msg.event || msg);
+        break;
+      case 'final':
+        this._handleFinal(task, msg);
+        break;
+      case 'error':
+        this._markError(task, msg.message || '执行失败');
+        break;
+      case 'status':
+        task.statusText = msg.state || task.statusText;
+        if (msg.state === 'completed' && task.status !== 'done') {
+          // 等待 final 事件
+        }
+        this._updateTaskElement(task);
+        break;
+      default:
+        this._handleLog(task, { ts: msg.ts, line: JSON.stringify(msg) });
+    }
+  }
+
+  _handleProgress(task, data) {
+    if (!task) return;
+    const stage = (data.stage || 'progress').toLowerCase();
+    const status = (data.status || '').toLowerCase();
+    const ts = data.ts || new Date().toISOString();
+    const message = data.message || '';
+    task.progress = {
+      stage,
+      status,
+      message,
+      ts,
+      percent: this._calcProgressPercent({ ...task, progress: { stage, status } })
+    };
+    if (!task.stages) task.stages = new Map();
+    task.stages.set(stage, { status, message, ts, extra: data.extra });
+    this._pushLog(task, { type: 'progress', stage, status, message, ts, extra: data.extra });
+    this._updateTaskElement(task);
+    if (this.detail.currentId === task.id && (!task.traceId || task.status !== 'done')) {
+      this._renderLiveDetail(task);
+    }
+  }
+
+  _handleLog(task, msg) {
+    if (!task) return;
+    this._pushLog(task, { type: 'log', ts: msg.ts, line: msg.line });
+    if (this.detail.currentId === task.id && (!task.traceId || task.status !== 'done')) {
+      this._renderLiveDetail(task);
+    }
+  }
+
+  _handleEvent(task, event) {
+    if (!task) return;
+    const payload = event && event.payload ? event : { payload: event };
+    const type = ((event && event.type) || (payload.payload && payload.payload.type) || '').toLowerCase();
+    if (!task.events) task.events = [];
+    task.events.push({ ...payload, type: event && event.type ? event.type : type });
+    if (type.includes('approval')) {
+      this._enterApproval(task, payload.payload || payload);
+    }
+    if (type.includes('budget')) {
+      const message = payload.payload && (payload.payload.message || payload.payload.reason) || '预算提示';
+      this.showBudgetNotice(task, { message, payload: payload.payload || payload });
+      if (this.options.onBudget) {
+        this.options.onBudget(task, { message, payload: payload.payload || payload });
+      }
+    }
+    if (this.detail.currentId === task.id && task.status !== 'done') {
+      this._renderLiveDetail(task);
+    }
+  }
+
+  _enterApproval(task, payload) {
+    task.status = 'approval';
+    task.approvalPayload = payload;
+    task.approvalMessage = (payload && (payload.message || payload.reason)) || '等待审批';
+    this._setTaskGroup(task, 'approval');
+    this._updateTaskElement(task);
+    if (this.options.onApproval) {
+      this.options.onApproval(task, payload);
+    }
+  }
+
+  _handleFinal(task, msg) {
+    task.status = 'done';
+    const traceId = msg.trace_id || (msg.result && msg.result.trace_id) || task.traceId;
+    if (traceId) {
+      const newId = `ep-${traceId}`;
+      if (task.id !== newId) {
+        this.tasks.delete(task.id);
+        task.id = newId;
+        this.tasks.set(newId, task);
+      }
+      task.traceId = traceId;
+    }
+    task.result = msg.result || task.result;
+    task.episode = msg.episode || task.episode;
+    task.statusText = (msg.episode && msg.episode.status) || task.statusText || 'completed';
+    if (msg.episode && msg.episode.goal) {
+      task.title = msg.episode.goal;
+      task.goal = msg.episode.goal;
+    }
+    task.completedAt = new Date().toISOString();
+    this.hideBudgetNotice();
+    this._setTaskGroup(task, 'done');
+    this._updateTaskElement(task);
+    if (this.detail.currentId === task.id) {
+      this._fetchEpisodeDetail(task);
+    }
+  }
+
+  _markError(task, message) {
+    task.status = 'failed';
+    task.error = message;
+    this._setTaskGroup(task, 'done');
+    this._updateTaskElement(task);
+    if (this.options.appendMessage) {
+      this.options.appendMessage('系统', message);
+    }
+  }
+
+  _pushLog(task, entry) {
+    if (!task.logs) task.logs = [];
+    task.logs.push(entry);
+    if (task.logs.length > 80) {
+      task.logs.splice(0, task.logs.length - 80);
+    }
+  }
+
+  async _fetchEpisodeDetail(task) {
+    if (!task.traceId) {
+      this._renderLiveDetail(task);
+      return;
+    }
+    try {
+      const resp = await fetch(`/api/episodes/${encodeURIComponent(task.traceId)}`);
+      const data = await resp.json();
+      if (data.ok) {
+        task.episodeDetail = data.episode;
+        task.episodeDetailLoaded = true;
+        if (this.detail.currentId === task.id) {
+          this._renderEpisodeDetail(task);
+        }
+      } else {
+        this._renderDetailError(task, data.error || '加载 Episode 失败');
+      }
+    } catch (err) {
+      this._renderDetailError(task, err.message);
+    }
+  }
+
+  _renderDetailError(task, msg) {
+    if (!this.detail || this.detail.currentId !== task.id || !this.detail.body) return;
+    this.detail.body.innerHTML = `<div class="task-detail-section"><div class="task-detail-item">${escapeHtml(msg)}</div></div>`;
+  }
+
+  _renderLiveDetail(task) {
+    if (!this.detail || this.detail.currentId !== task.id || !this.detail.body) return;
+    const stages = [];
+    if (task.stages) {
+      for (const [id, info] of task.stages.entries()) {
+        const line = `<div class="task-detail-item"><strong>${stageLabel(id)}</strong> — ${escapeHtml(info.status || '')}
+          ${info.ts ? `<span class="hint">${escapeHtml(formatTimestamp(info.ts))}</span>` : ''}
+          ${info.message ? `<div class="task-detail-item">${escapeHtml(info.message)}</div>` : ''}
+          ${info.extra ? `<pre>${escapeHtml(JSON.stringify(info.extra, null, 2))}</pre>` : ''}
+        </div>`;
+        stages.push(line);
+      }
+    }
+    const logs = (task.logs || []).slice(-20).map((log) => {
+      const body = log.line ? `<pre>${escapeHtml(log.line)}</pre>` : '';
+      const desc = log.stage ? `${stageLabel(log.stage)} ${escapeHtml(log.status || '')}` : '';
+      return `<div class="task-detail-log">
+        <div class="hint">${escapeHtml(formatTimestamp(log.ts || ''))}</div>
+        ${desc ? `<div class="task-detail-item">${desc}</div>` : ''}
+        ${body}
+      </div>`;
+    });
+    const progress = task.progress ? `<div class="task-detail-item"><strong>${stageLabel(task.progress.stage)}</strong> — ${escapeHtml(task.progress.status || '')}</div>` : '<div class="hint">尚未开始</div>';
+    this.detail.body.innerHTML = `
+      <div class="task-detail-section">
+        <h4>当前阶段</h4>
+        ${progress}
+        ${task.progress && task.progress.message ? `<div class="task-detail-item">${escapeHtml(task.progress.message)}</div>` : ''}
+      </div>
+      <div class="task-detail-section">
+        <h4>阶段进度</h4>
+        ${stages.length ? stages.join('') : '<div class="hint">暂无阶段信息</div>'}
+      </div>
+      <div class="task-detail-section">
+        <h4>执行日志</h4>
+        ${logs.length ? logs.join('') : '<div class="hint">暂无日志</div>'}
+      </div>
+    `;
+  }
+
+  _renderEpisodeDetail(task) {
+    if (!this.detail || this.detail.currentId !== task.id || !this.detail.body) return;
+    const ep = task.episodeDetail || task.episode || {};
+    if (this.detail.title) {
+      this.detail.title.textContent = ep.goal || task.title || `Episode ${task.traceId}`;
+    }
+    if (this.detail.subtitle) {
+      const summary = [task.traceId ? `trace ${task.traceId}` : '', ep.status ? `状态 ${ep.status}` : '']
+        .filter(Boolean)
+        .join(' • ');
+      this.detail.subtitle.textContent = summary;
+    }
+    const header = ep.header || {};
+    const summaryParts = [
+      header.provider ? `provider: ${escapeHtml(header.provider)}` : '',
+      header.model ? `model: ${escapeHtml(header.model)}` : '',
+      header.cost !== undefined ? `cost: ${escapeHtml(header.cost)}` : '',
+      ep.latency_ms !== undefined ? `latency: ${escapeHtml(ep.latency_ms)}ms` : ''
+    ].filter(Boolean);
+    const events = Array.isArray(ep.events) ? ep.events : [];
+    const eventHtml = events.slice(-20).map((ev) => {
+      const payload = ev.payload ? JSON.stringify(ev.payload, null, 2) : '';
+      return `<div class="task-detail-log">
+        <div class="hint">${escapeHtml(formatTimestamp(ev.ts || ''))}</div>
+        <div class="task-detail-item"><strong>${escapeHtml(ev.type || '')}</strong></div>
+        ${payload ? `<pre>${escapeHtml(payload)}</pre>` : ''}
+      </div>`;
+    });
+    this.detail.body.innerHTML = `
+      <div class="task-detail-section">
+        <h4>概要</h4>
+        <div class="task-detail-item">trace：${escapeHtml(task.traceId || '')}</div>
+        ${summaryParts.length ? `<div class="task-detail-item">${summaryParts.join(' • ')}</div>` : ''}
+        ${ep.artifacts && ep.artifacts.output_path ? `<div class="task-detail-item">产物：${escapeHtml(ep.artifacts.output_path)}</div>` : ''}
+      </div>
+      <div class="task-detail-section">
+        <h4>事件</h4>
+        ${eventHtml.length ? eventHtml.join('') : '<div class="hint">暂无事件</div>'}
+      </div>
+    `;
+  }
+}

--- a/apps/server/static/chat/tasks.js
+++ b/apps/server/static/chat/tasks.js
@@ -493,6 +493,8 @@ export class TaskManager {
   }
 
   _handleFinal(task, msg) {
+    if (!task) return;
+    const oldId = task.id;
     task.status = 'done';
     const traceId = msg.trace_id || (msg.result && msg.result.trace_id) || task.traceId;
     if (traceId) {
@@ -501,6 +503,15 @@ export class TaskManager {
         this.tasks.delete(task.id);
         task.id = newId;
         this.tasks.set(newId, task);
+        if (task.element) {
+          task.element.dataset.taskId = newId;
+        }
+        if (this.detail && this.detail.currentId === oldId) {
+          this.detail.currentId = newId;
+        }
+        if (this.budget && this.budget.currentTaskId === oldId) {
+          this.budget.currentTaskId = newId;
+        }
       }
       task.traceId = traceId;
     }
@@ -515,7 +526,7 @@ export class TaskManager {
     this.hideBudgetNotice();
     this._setTaskGroup(task, 'done');
     this._updateTaskElement(task);
-    if (this.detail.currentId === task.id) {
+    if (this.detail && this.detail.currentId === task.id) {
       this._fetchEpisodeDetail(task);
     }
   }

--- a/apps/server/static/chat/tools.js
+++ b/apps/server/static/chat/tools.js
@@ -1,0 +1,116 @@
+export function setupToolsPanel({ toggleButton, panelEl, hintEl, spinEl, appendMessage }) {
+  if (!panelEl) {
+    return { load: async () => {} };
+  }
+
+  const setHint = (msg) => {
+    if (hintEl) hintEl.textContent = msg || '';
+  };
+
+  const setSpin = (on) => {
+    if (spinEl) spinEl.style.display = on ? 'inline-block' : 'none';
+  };
+
+  const renderTools = (serverId, tools, fallback) => {
+    let html = `<div style="display:flex;gap:8px;align-items:center"><b>工具</b><label>server:</label><input id="toolServer" value="${serverId}" style="width:120px"></div>`;
+    if (fallback) {
+      html += `<div class="hint" style="margin-top:4px">使用本地回退清单：${fallback}</div>`;
+    }
+    if (!Array.isArray(tools) || tools.length === 0) {
+      html += '<div class="hint" style="margin-top:8px">无可用工具</div>';
+      panelEl.innerHTML = html;
+      panelEl.style.display = 'block';
+      return;
+    }
+    html += '<div style="margin-top:6px">';
+    for (const t of tools) {
+      const dn = t.name || '';
+      const desc = t.description || '';
+      html += '<div style="border-top:1px solid var(--border); padding:6px 0">'
+        + `<div><b>${dn}</b></div>`
+        + (desc ? `<div class="hint">${desc}</div>` : '')
+        + '<div style="display:flex;gap:6px;align-items:center;margin-top:4px">'
+        + '<span class="hint">args(JSON):</span>'
+        + `<input id="arg_${dn}" style="flex:1" value="{}">`
+        + `<button data-tool="${dn}">调用</button>`
+        + '</div>'
+        + '</div>';
+    }
+    html += '</div>';
+    panelEl.innerHTML = html;
+    panelEl.style.display = 'block';
+    panelEl.querySelectorAll('button[data-tool]').forEach((btn) => {
+      btn.addEventListener('click', async () => {
+        const tool = btn.getAttribute('data-tool');
+        const serverInput = panelEl.querySelector('#toolServer');
+        const server = serverInput ? serverInput.value || 'api' : 'api';
+        const argInput = panelEl.querySelector(`#arg_${tool}`);
+        let argsJson = '{}';
+        if (argInput) {
+          try {
+            argsJson = argInput.value || '{}';
+          } catch (err) {
+            console.warn('args parse error', err);
+          }
+        }
+        const fd = new FormData();
+        fd.append('server', server);
+        fd.append('tool', tool);
+        fd.append('args_json', argsJson);
+        try {
+          setHint(`执行 ${tool}…`);
+          setSpin(true);
+          const resp = await fetch('/api/mcp/call', { method: 'POST', body: fd });
+          const data = await resp.json();
+          if (data.ok) {
+            const res = data.result || {};
+            const txt = res.text || (res.structured ? JSON.stringify(res.structured, null, 2) : '');
+            if (appendMessage) {
+              appendMessage('助手', `[MCP ${server}.${tool}]\n${txt || '<no result>'}`);
+            }
+          } else if (appendMessage) {
+            appendMessage('系统', `调用失败: ${data.error || ''}`);
+          }
+        } catch (err) {
+          if (appendMessage) {
+            appendMessage('系统', `调用失败: ${err.message}`);
+          }
+        } finally {
+          setHint('');
+          setSpin(false);
+        }
+      });
+    });
+  };
+
+  const load = async (server = 'api') => {
+    try {
+      setHint('加载工具中…');
+      const resp = await fetch(`/api/mcp/tools?server=${encodeURIComponent(server)}`);
+      const data = await resp.json();
+      if (!data.ok) {
+        panelEl.style.display = 'block';
+        panelEl.innerHTML = `<b>工具</b><div class="hint">加载失败: ${data.error || ''}</div>`;
+        return;
+      }
+      renderTools(data.server || server, data.tools || [], data.fallback ? data.error : '');
+      setHint('');
+    } catch (err) {
+      panelEl.style.display = 'block';
+      panelEl.innerHTML = `<b>工具</b><div class="hint">加载失败: ${err.message}</div>`;
+    }
+  };
+
+  if (toggleButton) {
+    toggleButton.addEventListener('click', () => {
+      const visible = panelEl.style.display !== 'none' && panelEl.style.display !== '';
+      if (visible) {
+        panelEl.style.display = 'none';
+      } else {
+        load('api');
+      }
+    });
+  }
+
+  return { load };
+}

--- a/apps/server/static/chat/workspace.js
+++ b/apps/server/static/chat/workspace.js
@@ -1,0 +1,164 @@
+const jsonFetch = async (url, options = {}) => {
+  const resp = await fetch(url, options);
+  if (!resp.ok) {
+    throw new Error(`请求失败: ${resp.status}`);
+  }
+  return resp.json();
+};
+
+export function setupWorkspaceDrawer({
+  drawer,
+  openButton,
+  closeButton,
+  backdrop,
+  treeEl,
+  cwdEl,
+  previewWrap,
+  selectedPathEl,
+  contentEl,
+  hintEl,
+  tokenInput,
+  insertButton,
+  saveButton,
+  onInsert,
+  initialPath = 'examples'
+}) {
+  if (!drawer) return { open: () => {}, close: () => {}, reload: () => {} };
+
+  const ls = async (path) => jsonFetch(`/api/ws/ls?path=${encodeURIComponent(path || '.')}`);
+  const read = async (path) => jsonFetch(`/api/ws/read?path=${encodeURIComponent(path)}`);
+  const write = async (path, content) => {
+    const fd = new FormData();
+    fd.append('path', path);
+    fd.append('content', content);
+    const headers = {};
+    if (tokenInput && tokenInput.value) {
+      headers['X-Admin-Token'] = tokenInput.value;
+    }
+    const resp = await fetch('/api/ws/write', { method: 'POST', body: fd, headers });
+    if (!resp.ok) {
+      throw new Error(`保存失败: ${resp.status}`);
+    }
+    return resp.json();
+  };
+
+  const open = () => drawer.classList.add('open');
+  const close = () => drawer.classList.remove('open');
+
+  if (openButton) openButton.addEventListener('click', open);
+  if (closeButton) closeButton.addEventListener('click', close);
+  if (backdrop) backdrop.addEventListener('click', close);
+
+  const renderTree = (cwd, dirs = [], files = []) => {
+    if (!treeEl) return;
+    if (cwdEl) cwdEl.textContent = cwd || '/';
+    const ul = document.createElement('ul');
+    ul.style.listStyle = 'none';
+    ul.style.paddingLeft = '0';
+
+    const makeLink = (label, handler) => {
+      const link = document.createElement('a');
+      link.href = '#';
+      link.textContent = label;
+      link.addEventListener('click', (ev) => {
+        ev.preventDefault();
+        handler();
+      });
+      return link;
+    };
+
+    const up = document.createElement('li');
+    const upLink = makeLink('..', () => {
+      const parent = cwd ? cwd.split('/').slice(0, -1).join('/') : '';
+      loadDir(parent);
+    });
+    up.appendChild(upLink);
+    ul.appendChild(up);
+
+    dirs.forEach((d) => {
+      const li = document.createElement('li');
+      li.textContent = '📁 ';
+      const link = makeLink(d, () => loadDir((cwd ? `${cwd}/` : '') + d));
+      li.appendChild(link);
+      ul.appendChild(li);
+    });
+
+    files.forEach((f) => {
+      const li = document.createElement('li');
+      const name = f.name || f;
+      const size = f.size ? ` (${f.size})` : '';
+      li.textContent = '📄 ';
+      const link = makeLink(name, async () => {
+        try {
+          const rel = (cwd ? `${cwd}/` : '') + name;
+          const data = await read(rel);
+          if (data.ok) {
+            if (previewWrap) previewWrap.style.display = 'block';
+            if (selectedPathEl) selectedPathEl.textContent = rel;
+            if (contentEl) contentEl.value = data.content || '';
+            if (hintEl) hintEl.textContent = '';
+          } else if (hintEl) {
+            hintEl.textContent = data.error || '读取失败';
+          }
+        } catch (err) {
+          if (hintEl) hintEl.textContent = err.message;
+        }
+      });
+      li.appendChild(link);
+      const meta = document.createElement('span');
+      meta.style.color = '#999';
+      meta.style.fontSize = '12px';
+      meta.textContent = size;
+      li.appendChild(meta);
+      ul.appendChild(li);
+    });
+
+    treeEl.innerHTML = '';
+    treeEl.appendChild(ul);
+  };
+
+  const loadDir = async (path) => {
+    try {
+      const data = await ls(path || '.');
+      if (data.ok) {
+        renderTree(data.cwd || path || '.', data.dirs || [], data.files || []);
+        if (hintEl) hintEl.textContent = '';
+      } else if (hintEl) {
+        hintEl.textContent = data.error || '加载失败';
+      }
+    } catch (err) {
+      if (hintEl) hintEl.textContent = err.message;
+    }
+  };
+
+  if (insertButton && onInsert) {
+    insertButton.addEventListener('click', () => {
+      if (!selectedPathEl || !contentEl) return;
+      const p = selectedPathEl.textContent;
+      if (!p) return;
+      onInsert(p, contentEl.value);
+    });
+  }
+
+  if (saveButton) {
+    saveButton.addEventListener('click', async () => {
+      if (!selectedPathEl || !contentEl) return;
+      const path = selectedPathEl.textContent;
+      if (!path) return;
+      if (hintEl) hintEl.textContent = '保存中…';
+      try {
+        const data = await write(path, contentEl.value);
+        if (hintEl) hintEl.textContent = data.ok ? '已保存' : (data.error || '保存失败');
+        setTimeout(() => {
+          if (hintEl) hintEl.textContent = '';
+        }, 2000);
+      } catch (err) {
+        if (hintEl) hintEl.textContent = err.message;
+      }
+    });
+  }
+
+  loadDir(initialPath);
+
+  return { open, close, reload: loadDir };
+}

--- a/apps/server/static/style.css
+++ b/apps/server/static/style.css
@@ -174,6 +174,74 @@ code { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
 .msg.user .bubble { background: var(--primary); color: #fff; border-color: var(--primary); }
 .msg .meta { font-size: 12px; color: var(--muted); margin: 4px 8px; }
 
+/* Chat 页面布局 */
+.chat-layout { display: flex; gap: 16px; align-items: flex-start; }
+.chat-main { flex: 2 1 520px; min-width: 0; display: flex; flex-direction: column; gap: 12px; }
+.task-sidebar { flex: 1 1 280px; display: flex; flex-direction: column; gap: 12px; min-width: 260px; }
+
+.task-panel-header { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+.task-panel-header h3 { margin: 0; }
+
+.task-group { margin-top: 12px; }
+.task-group-header { font-weight: 600; font-size: 14px; color: var(--text); display: flex; align-items: center; gap: 6px; }
+.task-list { margin-top: 8px; display: flex; flex-direction: column; gap: 8px; }
+.task-empty { font-size: 12px; color: var(--muted); padding: 6px 0; }
+
+.task-item { border: 1px solid var(--border); border-radius: 10px; padding: 10px 12px; background: color-mix(in srgb, var(--panel) 92%, var(--primary-100)); cursor: pointer; transition: border-color .15s ease, transform .15s ease; }
+.task-item:hover { border-color: var(--primary); transform: translateY(-1px); }
+.task-item.error { border-color: var(--danger); background: color-mix(in srgb, var(--panel) 90%, #fee2e2); }
+.task-item.success { border-color: var(--success); background: color-mix(in srgb, var(--panel) 90%, #dcfce7); }
+.task-item .task-title { font-weight: 600; font-size: 14px; }
+.task-item .task-meta { font-size: 12px; color: var(--muted); margin-top: 4px; }
+.task-item .task-extra { font-size: 12px; color: var(--muted); margin-top: 6px; }
+.task-item-header { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+.task-badge { font-size: 11px; padding: 2px 6px; border-radius: 999px; background: var(--primary-100); color: var(--primary); border: 1px solid var(--primary-200); }
+.task-badge.neutral { background: color-mix(in srgb, var(--panel) 92%, var(--border)); color: var(--muted); border-color: var(--border); }
+.task-badge.danger { background: #fee2e2; color: var(--danger); border-color: #fecaca; }
+.task-badge.success { background: #dcfce7; color: var(--success); border-color: #86efac; }
+
+.task-progress { margin-top: 8px; height: 6px; border-radius: 999px; background: color-mix(in srgb, var(--panel) 85%, var(--primary-100)); overflow: hidden; }
+.task-progress-bar { height: 100%; width: 0%; background: var(--primary); transition: width .2s ease; }
+.task-progress-bar.slow { background: var(--warning); }
+.task-progress-bar.error { background: var(--danger); }
+
+.task-detail-header { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+.task-detail-body { margin-top: 8px; display: flex; flex-direction: column; gap: 10px; max-height: 420px; overflow: auto; }
+.task-detail-body pre { background: color-mix(in srgb, var(--panel) 88%, var(--primary-100)); border-radius: 8px; padding: 10px; border: 1px solid var(--border); font-size: 12px; }
+.task-detail-section { border: 1px solid var(--border); border-radius: 8px; padding: 10px; background: color-mix(in srgb, var(--panel) 94%, var(--primary-100)); }
+.task-detail-section h4 { margin: 0 0 6px 0; font-size: 14px; }
+.task-detail-item { font-size: 12px; color: var(--muted); margin-top: 4px; }
+.task-detail-item strong { color: var(--text); }
+.task-detail-log { border-top: 1px solid var(--border); padding-top: 6px; margin-top: 6px; }
+.task-detail-log:first-child { border-top: none; padding-top: 0; margin-top: 0; }
+
+.budget-banner { margin-top: 10px; border: 1px solid #fcd34d; background: #fef3c7; color: #92400e; border-radius: 10px; padding: 10px 12px; display: none; }
+.budget-banner .budget-title { font-weight: 600; margin-bottom: 4px; }
+.budget-banner .budget-meta { font-size: 12px; color: #b45309; margin-top: 4px; }
+
+.modal { position: fixed; inset: 0; display: flex; align-items: center; justify-content: center; pointer-events: none; opacity: 0; transition: opacity .2s ease; z-index: 50; }
+.modal.open { pointer-events: auto; opacity: 1; }
+.modal .modal-backdrop { position: absolute; inset: 0; background: rgba(15, 23, 42, 0.4); backdrop-filter: blur(4px); }
+.modal .modal-panel { position: relative; background: var(--panel); border-radius: var(--radius); padding: 18px; min-width: min(420px, 92vw); box-shadow: var(--shadow); border: 1px solid var(--border); display: flex; flex-direction: column; gap: 12px; }
+.modal-header { display: flex; align-items: center; justify-content: space-between; gap: 8px; font-weight: 600; }
+.modal-body { max-height: 320px; overflow: auto; font-size: 14px; color: var(--text); }
+.modal-body pre { background: color-mix(in srgb, var(--panel) 90%, var(--primary-100)); border-radius: 8px; padding: 10px; border: 1px solid var(--border); font-size: 12px; }
+.modal-actions { display: flex; gap: 10px; justify-content: flex-end; }
+
+.btn.small { padding: 6px 10px; font-size: 12px; box-shadow: none; }
+.btn.danger { background: var(--danger); box-shadow: 0 6px 16px rgba(220, 38, 38, .25); }
+.btn.danger:hover { filter: brightness(1.05); }
+
+@media (max-width: 980px) {
+  .chat-layout { flex-direction: column; }
+  .task-sidebar { width: 100%; }
+}
+
+@media (max-width: 640px) {
+  .chat-main { flex: 1 1 auto; }
+  .task-sidebar { min-width: 0; }
+}
+
 /* Ghost 按钮 */
 .btn.ghost { background: transparent; color: var(--text); border: 1px solid var(--border); box-shadow: none; }
 .btn.ghost:hover { background: color-mix(in srgb, var(--panel) 85%, var(--primary-100)); }

--- a/apps/server/templates/chat.html
+++ b/apps/server/templates/chat.html
@@ -9,15 +9,59 @@
   <span id="chatSpin" class="spinner" style="display:none"></span>
 </div>
 
-<div id="chatPane">
-  <div id="chatBox" class="chat-box"></div>
-  <form id="chatForm" class="sticky-input" method="post" action="/api/chat/send">
-    <input type="hidden" name="session" id="chatSession">
-    <input name="text" style="width:70%" placeholder="请输入需求…"> <button type="submit">发送</button>
-    <div class="hint" style="margin-top:4px">提示：描述你的需求可生成 SRS 草稿或运行建议。点击右上“工作区”可浏览/编辑文件并插入到对话。</div>
-  </form>
-  <div id="actionBox" class="card" style="margin-top:8px"></div>
-  <div id="toolsPanel" class="card" style="margin-top:8px; display:none"></div>
+<div class="chat-layout" id="chatLayout">
+  <div class="chat-main">
+    <div id="chatBox" class="chat-box"></div>
+    <form id="chatForm" class="sticky-input" method="post" action="/api/chat/send">
+      <input type="hidden" name="session" id="chatSession">
+      <input name="text" style="width:70%" placeholder="请输入需求…"> <button type="submit">发送</button>
+      <div class="hint" style="margin-top:4px">提示：描述你的需求可生成 SRS 草稿或运行建议。点击右上“工作区”可浏览/编辑文件并插入到对话。</div>
+    </form>
+    <div id="actionBox" class="card"></div>
+    <div id="toolsPanel" class="card" style="display:none"></div>
+  </div>
+  <aside class="task-sidebar">
+    <div class="card" id="taskPanel">
+      <div class="task-panel-header">
+        <h3>任务列表</h3>
+        <button id="refreshTasks" class="btn ghost small">刷新</button>
+      </div>
+      <div class="hint">实时关注最小闭环的执行状态与审批请求。</div>
+      <div id="budgetBanner" class="budget-banner">
+        <div class="budget-title">预算提示</div>
+        <div id="budgetMessage"></div>
+        <div id="budgetPayload" class="budget-meta"></div>
+        <div style="margin-top:6px; display:flex; justify-content:flex-end">
+          <button id="budgetDismiss" class="btn ghost small">知道了</button>
+        </div>
+      </div>
+      <div class="task-group" data-group="running">
+        <div class="task-group-header">进行中</div>
+        <div class="task-list" id="taskListRunning"></div>
+        <div class="task-empty" id="taskEmptyRunning">暂无进行中任务</div>
+      </div>
+      <div class="task-group" data-group="approval">
+        <div class="task-group-header">待审批</div>
+        <div class="task-list" id="taskListApproval"></div>
+        <div class="task-empty" id="taskEmptyApproval">暂无审批任务</div>
+      </div>
+      <div class="task-group" data-group="done">
+        <div class="task-group-header">已完成</div>
+        <div class="task-list" id="taskListDone"></div>
+        <div class="task-empty" id="taskEmptyDone">暂无历史记录</div>
+      </div>
+    </div>
+    <div class="card" id="taskDetailCard" style="display:none">
+      <div class="task-detail-header">
+        <div>
+          <div id="taskDetailTitle">Episode</div>
+          <div class="hint" id="taskDetailSubtitle"></div>
+        </div>
+        <button id="taskDetailClose" class="btn ghost small">关闭</button>
+      </div>
+      <div id="taskDetailBody" class="task-detail-body"></div>
+    </div>
+  </aside>
 </div>
 
 <!-- 工作区抽屉 -->
@@ -45,213 +89,26 @@
     </div>
   </div>
 </div>
-<script>
-const box = document.getElementById('chatBox');
-const form = document.getElementById('chatForm');
-const sess = document.getElementById('chatSession');
-const hint = document.getElementById('chatHint');
-const spin = document.getElementById('chatSpin');
-const actionBox = document.getElementById('actionBox');
-const wsTree = document.getElementById('wsTree');
-const wsCwd = document.getElementById('wsCwd');
-const wsPreviewWrap = document.getElementById('wsPreviewWrap');
-const wsSel = document.getElementById('wsSel');
-const wsContent = document.getElementById('wsContent');
-const wsHint = document.getElementById('wsHint');
-const wsToken = document.getElementById('wsToken');
-const wsDrawer = document.getElementById('wsDrawer');
-const btnWs = document.getElementById('btnWs');
-const btnTools = document.getElementById('btnTools');
-const btnCloseWs = document.getElementById('btnCloseWs');
-const wsBackdrop = wsDrawer?.querySelector('.backdrop');
-if(!sess.value){ sess.value = 's-'+Math.random().toString(16).slice(2,10); }
 
-// Chat 区域
-function fmtTime(){ const d = new Date(); return d.toTimeString().slice(0,5); }
-function append(role, text){
-  const me = role === '你' || role === 'user';
-  const wrap = document.createElement('div');
-  wrap.className = 'msg'+(me?' user':'');
-  const bubble = document.createElement('div');
-  bubble.className = 'bubble';
-  bubble.innerHTML = (me?'<b>你</b>':'<b>助手</b>') + ' · <span class="meta">'+fmtTime()+'</span><br>' + String(text).replace(/\n/g,'<br>');
-  wrap.appendChild(bubble);
-  box.appendChild(wrap); box.scrollTop = box.scrollHeight;
-}
-async function loadHistory(){
-  const resp = await fetch('/api/chat/history?session='+encodeURIComponent(sess.value));
-  const data = await resp.json();
-  if(data.ok){
-    box.innerHTML='';
-    for(const m of data.history){ append(m.role==='user'?'你':'助手', m.content); }
-  }
-}
-form.addEventListener('submit', async (e)=>{
-  e.preventDefault();
-  const fd = new FormData(form);
-  const text = fd.get('text');
-  if(!text) return;
-  append('你', String(text));
-  form.text.value=''; hint.textContent='思考中…'; if(spin) spin.style.display='inline-block';
-  const resp = await fetch(form.action, {method:'POST', body:fd});
-  const data = await resp.json();
-  hint.textContent=''; if(spin) spin.style.display='none';
-  if(data.ok){ append('助手', data.reply); }
-  else{ append('系统', '发送失败'); }
-  // 渲染 action 卡片
-  actionBox.innerHTML='';
-  if(data.action && data.action.type==='run'){
-    const args = data.action.args || {};
-    const div = document.createElement('div');
-    div.className = 'card';
-    div.innerHTML = '<b>执行建议</b> — type=run' +
-      '<div>args: <pre>'+JSON.stringify(args,null,2)+'</pre></div>' +
-      (data.srs_path?('<div>SRS 已保存: '+data.srs_path+'</div>'):'') +
-      '<button id="btnRunNow">立即运行</button> <button id="btnEditRun">编辑并运行</button>';
-    actionBox.appendChild(div);
-    const btn = div.querySelector('#btnRunNow');
-    btn.addEventListener('click', async ()=>{
-      const fd2 = new FormData();
-      fd2.append('srs_path', args.srs_path || 'examples/srs/weekly_report.json');
-      fd2.append('data_path', args.data_path || 'examples/data/weekly.csv');
-      fd2.append('out_path', args.out || 'reports/weekly_report.md');
-      fd2.append('planner', args.planner || 'llm');
-      fd2.append('executor', args.executor || 'llm');
-      fd2.append('critic', args.critic || 'llm');
-      fd2.append('reviser', args.reviser || 'llm');
-      if(args.provider) fd2.append('provider', args.provider);
-      hint.textContent='开始执行…';
-      const r2 = await fetch('/api/run', {method:'POST', body:fd2});
-      const j2 = await r2.json();
-      hint.textContent = j2.ok ? ('已提交，job='+ (j2.job_id||'')) : '提交失败';
-    });
-    const btnEdit = div.querySelector('#btnEditRun');
-    btnEdit.addEventListener('click', ()=>{
-      try{ localStorage.setItem('runArgs', JSON.stringify(args)); }catch(e){}
-      location.href = '/?tab=run';
-    });
-  }
-});
+<!-- 审批弹窗 -->
+<div class="modal" id="approvalModal" aria-hidden="true">
+  <div class="modal-backdrop"></div>
+  <div class="modal-panel">
+    <div class="modal-header">
+      <span>审批请求</span>
+      <button id="approvalClose" class="btn ghost small">关闭</button>
+    </div>
+    <div class="modal-body">
+      <div id="approvalMessage"></div>
+      <pre id="approvalPayload" style="display:none"></pre>
+    </div>
+    <div class="modal-actions">
+      <button class="btn danger" data-action="reject">终止任务</button>
+      <button class="btn ghost" data-action="downgrade">降级执行</button>
+      <button class="btn" data-action="approve">继续执行</button>
+    </div>
+  </div>
+</div>
 
-// Workspace 区域
-async function wsLs(path){
-  const r = await fetch('/api/ws/ls?path='+encodeURIComponent(path||'.'));
-  return await r.json();
-}
-async function wsRead(path){
-  const r = await fetch('/api/ws/read?path='+encodeURIComponent(path));
-  return await r.json();
-}
-async function wsWrite(path, content){
-  const fd = new FormData(); fd.append('path', path); fd.append('content', content);
-  const headers = {};
-  if(wsToken.value){ headers['X-Admin-Token'] = wsToken.value; }
-  const r = await fetch('/api/ws/write', {method:'POST', body:fd, headers});
-  return await r.json();
-}
-function renderTree(cwd, dirs, files){
-  wsCwd.textContent = cwd || '/';
-  const ul = document.createElement('ul'); ul.style.listStyle='none'; ul.style.paddingLeft='0';
-  const up = document.createElement('li');
-  up.innerHTML = '<a href="#">..</a>';
-  up.addEventListener('click', (e)=>{ e.preventDefault(); const parent = cwd? cwd.split('/').slice(0,-1).join('/') : ''; loadDir(parent); });
-  ul.appendChild(up);
-  for(const d of dirs){
-    const li = document.createElement('li'); li.innerHTML = '📁 <a href="#">'+d+'</a>';
-    li.querySelector('a').addEventListener('click', (e)=>{ e.preventDefault(); loadDir((cwd?cwd+'/':'')+d); });
-    ul.appendChild(li);
-  }
-  for(const f of files){
-    const li = document.createElement('li'); li.innerHTML = '📄 <a href="#">'+f.name+'</a> <span style="color:#999; font-size:12px">('+ (f.size||'') +')</span>';
-    li.querySelector('a').addEventListener('click', async (e)=>{ e.preventDefault(); const rel = (cwd?cwd+'/':'')+f.name; const j = await wsRead(rel); if(j.ok){ wsPreviewWrap.style.display='block'; wsSel.textContent = rel; wsContent.value = j.content; wsHint.textContent=''; } else { wsHint.textContent = j.error||'读取失败'; }});
-    ul.appendChild(li);
-  }
-  wsTree.innerHTML=''; wsTree.appendChild(ul);
-}
-async function loadDir(path){
-  const j = await wsLs(path||'.');
-  if(j.ok){ renderTree(j.cwd, j.dirs||[], j.files||[]); }
-}
-document.getElementById('btnInsert')?.addEventListener('click', ()=>{
-  if(!wsSel.textContent) return;
-  const text = '请参考文件 '+wsSel.textContent+" 的内容：\n\n```\n"+wsContent.value+"\n```\n";
-  form.text.value = text;
-});
-document.getElementById('btnSave')?.addEventListener('click', async ()=>{
-  const p = wsSel.textContent; if(!p) return;
-  wsHint.textContent = '保存中…';
-  const j = await wsWrite(p, wsContent.value);
-  wsHint.textContent = j.ok ? '已保存' : ('保存失败: '+(j.error||''));
-  setTimeout(()=>{ wsHint.textContent=''; }, 2000);
-});
-
-// Drawer 交互
-function openWs(){ wsDrawer?.classList.add('open'); }
-function closeWs(){ wsDrawer?.classList.remove('open'); }
-btnWs?.addEventListener('click', openWs);
-btnCloseWs?.addEventListener('click', closeWs);
-wsBackdrop?.addEventListener('click', closeWs);
-
-// 首次加载
-loadHistory();
-loadDir('examples');
-
-// 工具面板
-async function loadTools(server){
-  const resp = await fetch('/api/mcp/tools?server='+(server||'api'));
-  const j = await resp.json();
-  const panel = document.getElementById('toolsPanel');
-  if(!panel) return;
-  if(!j.ok){ panel.style.display='block'; panel.innerHTML = '<b>工具</b><div class="hint">加载失败: '+(j.error||'')+'</div>'; return; }
-  const serverId = j.server || 'api';
-  let html = '<div style="display:flex;gap:8px;align-items:center"><b>工具</b><label>server:</label><input id="toolServer" value="'+serverId+'" style="width:120px"></div>';
-  if(!j.tools || !j.tools.length){ html += '<div class="hint">无可用工具</div>'; panel.innerHTML = html; panel.style.display='block'; return; }
-  html += '<div style="margin-top:6px">';
-  for(const t of j.tools){
-    const dn = (t.name||'');
-    const desc = (t.description||'');
-    html += '<div style="border-top:1px solid #eee; padding:6px 0">'
-      + '<div><b>'+dn+'</b></div>'
-      + (desc?('<div class="hint">'+desc+'</div>'):'')
-      + '<div style="display:flex;gap:6px;align-items:center;margin-top:4px">'
-      + '<span class="hint">args(JSON):</span>'
-      + '<input id="arg_'+dn+'" style="flex:1" value="{}">'
-      + '<button data-tool="'+dn+'">调用</button>'
-      + '</div>'
-      + '</div>';
-  }
-  html += '</div>';
-  panel.innerHTML = html; panel.style.display='block';
-  panel.querySelectorAll('button[data-tool]').forEach(btn=>{
-    btn.addEventListener('click', async ()=>{
-      const tool = btn.getAttribute('data-tool');
-      const server = document.getElementById('toolServer').value || 'api';
-      const argInput = document.getElementById('arg_'+tool);
-      let argsJson = '{}';
-      try{ argsJson = argInput.value || '{}'; }catch(e){}
-      const fd = new FormData(); fd.append('server', server); fd.append('tool', tool); fd.append('args_json', argsJson);
-      hint.textContent='执行 '+tool+'…'; if(spin) spin.style.display='inline-block';
-      try{
-        const resp2 = await fetch('/api/mcp/call', {method:'POST', body: fd});
-        const j2 = await resp2.json();
-        if(j2.ok){
-          const res = j2.result || {}; const txt = res.text || (res.structured?JSON.stringify(res.structured):'');
-          append('助手', '[MCP '+server+'.'+tool+']\n'+(txt||'<no result>'));
-        } else {
-          append('系统', '调用失败: '+(j2.error||''));
-        }
-      }catch(e){
-        append('系统', '调用失败: '+String(e));
-      } finally {
-        hint.textContent=''; if(spin) spin.style.display='none';
-      }
-    });
-  });
-}
-btnTools?.addEventListener('click', ()=>{
-  const panel = document.getElementById('toolsPanel');
-  if(panel.style.display==='none'){ loadTools('api'); }
-  else { panel.style.display='none'; }
-});
-</script>
+<script type="module" src="{{ url_for('static', path='chat/index.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- rebuild the chat template with a task sidebar, budget banner, detail panel and approval modal driven by an ES module entry point
- add modular front-end scripts for chat orchestration, task management, workspace drawer and tools panel plus supporting styles
- expose episode listing/detail APIs and an approval endpoint on the backend to feed the new UI widgets

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68c8eabc4e9c832bbb57241fa070100f